### PR TITLE
Multilingual support

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -21,6 +21,8 @@ class AppKernel extends Kernel
             new JMS\SecurityExtraBundle\JMSSecurityExtraBundle(),
             new Intracto\SecretSantaBundle\IntractoSecretSantaBundle(),
             new Genemu\Bundle\FormBundle\GenemuFormBundle(),
+            new JMS\I18nRoutingBundle\JMSI18nRoutingBundle(),
+            new JMS\TranslationBundle\JMSTranslationBundle(),
         );
 
         if (in_array($this->getEnvironment(), array('dev', 'test'))) {

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -119,6 +119,7 @@ services:
             - @templating
             - @mailer
             - "%admin_email%"
+            - @translator
         tags:
             - { name: kernel.event_subscriber }
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -85,11 +85,14 @@ genemu_form:
     date: ~
 
 services:
-
     twig.text_extension:
         class: Twig_Extensions_Extension_Text
         tags:
             - name: twig.extension
+    twig.intl_extension:
+        class: Twig_Extensions_Extension_Intl
+        tags:
+            - { name: twig.extension }
 
     intracto.twig.linkify_extension:
         class: Intracto\SecretSantaBundle\Twig\LinkifyExtension

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -66,7 +66,7 @@ jms_di_extra:
 
 jms_i18n_routing:
     default_locale: "%locale%"
-    locales: [en, nl]
+    locales: %supported_locales%
     strategy: prefix_except_default
 
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -64,6 +64,20 @@ jms_di_extra:
     locations:
         all_bundles: true
 
+jms_i18n_routing:
+    default_locale: "%locale%"
+    locales: [en, nl]
+    strategy: prefix_except_default
+
+
+jms_translation:
+    configs:
+        app:
+            dirs: [%kernel.root_dir%, %kernel.root_dir%/../src]
+            output_dir: %kernel.root_dir%/Resources/translations
+            ignored_domains: [routes]
+            excluded_names: ["*TestCase.php", "*Test.php"]
+            excluded_dirs: [cache, data, logs]
 genemu_form:
     tinymce:
         enabled: true
@@ -71,6 +85,12 @@ genemu_form:
     date: ~
 
 services:
+
+    twig.text_extension:
+        class: Twig_Extensions_Extension_Text
+        tags:
+            - name: twig.extension
+
     intracto.twig.linkify_extension:
         class: Intracto\SecretSantaBundle\Twig\LinkifyExtension
         tags:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -24,6 +24,7 @@ twig:
     globals:
         ad_client:  %ad_client%
         ga_tracking:  %ga_tracking%
+        supported_locales:  %supported_locales%
 
 # Assetic Configuration
 assetic:
@@ -68,7 +69,6 @@ jms_i18n_routing:
     default_locale: "%locale%"
     locales: %supported_locales%
     strategy: prefix_except_default
-
 
 jms_translation:
     configs:
@@ -120,6 +120,12 @@ services:
             - @mailer
             - "%admin_email%"
             - @translator
+        tags:
+            - { name: kernel.event_subscriber }
+
+    intracto.locale_listener:
+        class: Intracto\SecretSantaBundle\EventListener\LocaleListener
+        arguments: ["%supported_locales%", @jms_i18n_routing.router]
         tags:
             - { name: kernel.event_subscriber }
 

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -13,7 +13,6 @@ parameters:
 
     locale:            en
     supported_locales: [en, nl]
-    locale_to_currency: [en => "$", nl => "€"]
 
     secret:            ThisTokenIsNotSoSecretChangeIt
     ad_client:         ca-pub-8492783089085834

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -12,7 +12,7 @@ parameters:
     mailer_password:   ~
 
     locale:            en
-    supported_locales: [en, nl]
+    supported_locales: [en, nl, fr]
 
     secret:            ThisTokenIsNotSoSecretChangeIt
     ad_client:         ca-pub-8492783089085834

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -12,6 +12,9 @@ parameters:
     mailer_password:   ~
 
     locale:            en
+    supported_locales: [en, nl]
+    locale_to_currency: [en => "$", nl => "€"]
+
     secret:            ThisTokenIsNotSoSecretChangeIt
     ad_client:         ca-pub-8492783089085834
     adwords_password:  secret

--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -10,5 +10,11 @@ _configurator:
     resource: "@SensioDistributionBundle/Resources/config/routing/webconfigurator.xml"
     prefix:   /_configurator
 
+
+JMSTranslationBundle_ui:
+    resource: @JMSTranslationBundle/Controller/
+    type:     annotation
+    prefix:   /_trans
+
 _main:
     resource: routing.yml

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
         "incenteev/composer-parameter-handler": "~2.0",
         "jms/security-extra-bundle": "1.5.*",
         "jms/di-extra-bundle": "1.4.*",
-        "genemu/form-bundle": "2.2.*"
+      "genemu/form-bundle": "2.2.*",
+      "jms/i18n-routing-bundle": "^1.1",
+      "jms/translation-bundle": "^1.1"
         },
     "scripts": {
         "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "45f5d9f3a63cbf2fe7752c5dd6faeab5",
+    "hash": "fb9640ed81a9fded93e421349f9d43ec",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -937,6 +937,74 @@
             "time": "2013-06-08 13:13:40"
         },
         {
+            "name": "jms/i18n-routing-bundle",
+            "version": "1.1.1",
+            "target-dir": "JMS/I18nRoutingBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/JMSI18nRoutingBundle.git",
+                "reference": "c58e4d99ae867f8b64a481c84cad89e1df03d1c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/JMSI18nRoutingBundle/zipball/c58e4d99ae867f8b64a481c84cad89e1df03d1c6",
+                "reference": "c58e4d99ae867f8b64a481c84cad89e1df03d1c6",
+                "shasum": ""
+            },
+            "require": {
+                "jms/translation-bundle": "~1.0",
+                "symfony/framework-bundle": "~2.1"
+            },
+            "require-dev": {
+                "jms/di-extra-bundle": "*",
+                "sensio/framework-extra-bundle": "<2.1.5",
+                "symfony/browser-kit": "<2.1.5",
+                "symfony/class-loader": "<2.1.5",
+                "symfony/css-selector": "<2.1.5",
+                "symfony/finder": "<2.1.5",
+                "symfony/form": "<2.1.5",
+                "symfony/framework-bundle": "<2.1.5",
+                "symfony/http-foundation": "<2.1.5",
+                "symfony/http-kernel": "<2.1.5",
+                "symfony/process": "<2.1.5",
+                "symfony/routing": "<2.1.5",
+                "symfony/twig-bundle": "<2.1.5",
+                "symfony/validator": "<2.1.5",
+                "symfony/yaml": "<2.1.5"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "JMS\\I18nRoutingBundle": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache2"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "https://github.com/schmittjoh",
+                    "role": "Developer of wrapped JMSSerializerBundle"
+                }
+            ],
+            "description": "This bundle allows you to create i18n routes.",
+            "homepage": "http://jmsyst.com/bundles/JMSI18nRoutingBundle",
+            "keywords": [
+                "multilanguage",
+                "routing",
+                "translation"
+            ],
+            "time": "2013-12-05 21:19:53"
+        },
+        {
             "name": "jms/metadata",
             "version": "1.5.1",
             "source": {
@@ -1095,6 +1163,80 @@
             "time": "2013-06-09 10:29:54"
         },
         {
+            "name": "jms/translation-bundle",
+            "version": "1.1.0",
+            "target-dir": "JMS/TranslationBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/JMSTranslationBundle.git",
+                "reference": "6f03035a38badaf8c48767c7664c3196df1eebdf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/JMSTranslationBundle/zipball/6f03035a38badaf8c48767c7664c3196df1eebdf",
+                "reference": "6f03035a38badaf8c48767c7664c3196df1eebdf",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "0.9.1",
+                "symfony/console": "*",
+                "symfony/framework-bundle": "~2.1"
+            },
+            "conflict": {
+                "twig/twig": "1.10.2"
+            },
+            "require-dev": {
+                "jms/di-extra-bundle": ">=1.1",
+                "sensio/framework-extra-bundle": "*",
+                "symfony/browser-kit": "*",
+                "symfony/class-loader": "*",
+                "symfony/css-selector": "*",
+                "symfony/finder": "*",
+                "symfony/form": "*",
+                "symfony/process": "*",
+                "symfony/security": "*",
+                "symfony/twig-bundle": "*",
+                "symfony/validator": "*",
+                "symfony/yaml": "*"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "JMS\\TranslationBundle": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache2"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "https://github.com/schmittjoh",
+                    "role": "Developer of wrapped JMSSerializerBundle"
+                }
+            ],
+            "description": "Puts the Symfony2 Translation Component on steroids",
+            "homepage": "http://jmsyst.com/bundles/JMSTranslationBundle",
+            "keywords": [
+                "extract",
+                "extraction",
+                "i18n",
+                "interface",
+                "multilanguage",
+                "translation",
+                "ui",
+                "webinterface"
+            ],
+            "time": "2013-06-08 14:08:19"
+        },
+        {
             "name": "kriswallsmith/assetic",
             "version": "v1.1.2",
             "source": {
@@ -1236,6 +1378,45 @@
                 "psr-3"
             ],
             "time": "2014-09-30 13:30:58"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v0.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "b1cc9ce676b4350b23d0fafc8244d08eee2fe287"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/b1cc9ce676b4350b23d0fafc8244d08eee2fe287",
+                "reference": "b1cc9ce676b4350b23d0fafc8244d08eee2fe287",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "PHPParser": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2012-04-23 22:52:11"
         },
         {
             "name": "phpoption/phpoption",
@@ -1809,12 +1990,12 @@
             "version": "v1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/fabpot/Twig-extensions.git",
+                "url": "https://github.com/twigphp/Twig-extensions.git",
                 "reference": "f91a82ec225e5bb108e01a0f93c9be04f84dcfa0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fabpot/Twig-extensions/zipball/f91a82ec225e5bb108e01a0f93c9be04f84dcfa0",
+                "url": "https://api.github.com/repos/twigphp/Twig-extensions/zipball/f91a82ec225e5bb108e01a0f93c9be04f84dcfa0",
                 "reference": "f91a82ec225e5bb108e01a0f93c9be04f84dcfa0",
                 "shasum": ""
             },
@@ -1914,6 +2095,7 @@
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.3.3"
     },

--- a/src/Intracto/SecretSantaBundle/Command/MailqueueCommand.php
+++ b/src/Intracto/SecretSantaBundle/Command/MailqueueCommand.php
@@ -68,7 +68,7 @@ class MailqueueCommand extends ContainerAwareCommand
             $translator->setLocale($receiver->getPool()->getLocale());
 
             $message = \Swift_Message::newInstance()
-                ->setSubject('Wishlist updated')
+                ->setSubject($translator->trans('emails.wishlistchanged.subject'))
                 ->setFrom($this->getContainer()->getParameter("admin_email"), $translator->trans('emails.sender'))
                 ->setTo($secret_santa->getEmail())
                 ->setBody(

--- a/src/Intracto/SecretSantaBundle/Controller/EntryController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/EntryController.php
@@ -86,9 +86,10 @@ class EntryController extends Controller
                 $em->persist($this->entry);
                 $em->flush();
 
+                $translator = $this->get('translator');
                 $this->get('session')->getFlashBag()->add(
                     'success',
-                    '<h4>Wishlist updated</h4>We\'ve sent out our gnomes to notify your Secret Santa about your wishes!'
+                    $translator->trans('flashes.entry.wishlist_updated')
                 );
 
                 if (!$inOrder) {
@@ -129,9 +130,10 @@ class EntryController extends Controller
             $emailAddressErrors = $validatorService->validate($emailAddress);
 
             if (count($emailAddressErrors) > 0) {
+                $translator = $this->get('translator');
                 $this->get('session')->getFlashBag()->add(
                     'error',
-                    '<h4>Not saved</h4> There is an error in the email address.'
+                    $translator->trans('flashes.entry.edit_email')
                 );
             } else {
                 $em = $this->getDoctrine()->getManager();
@@ -141,9 +143,10 @@ class EntryController extends Controller
                 $entryService = $this->get('intracto_secret_santa.entry_service');
                 $entryService->sendSecretSantaMailForEntry($entry);
 
+                $translator = $this->get('translator');
                 $this->get('session')->getFlashBag()->add(
                     'success',
-                    '<h4>Saved</h4> The new email address was saved. We also resent the e-mail.'
+                    $translator->trans('flashes.entry.saved_email')
                 );
             }
         }

--- a/src/Intracto/SecretSantaBundle/Controller/PoolController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/PoolController.php
@@ -178,7 +178,8 @@ class PoolController extends Controller
             'delete_pool',
             $this->getRequest()->get('csrf_token')
         );
-        $correctConfirmation = ($this->getRequest()->get('confirmation') === 'delete everything');
+        $translator = $this->get('translator');
+        $correctConfirmation = ($this->getRequest()->get('confirmation') === $translator->trans('delete.phrase_to_type'));
 
         if ($correctConfirmation === false || $correctCsrfToken === false) {
             $translator = $this->get('translator');

--- a/src/Intracto/SecretSantaBundle/Controller/PoolController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/PoolController.php
@@ -74,6 +74,7 @@ class PoolController extends Controller
                 ));
 
                 $pool->setMessage($message);
+                $pool->setLocale($request->getLocale());
                 $em->persist($pool);
                 $em->flush();
 

--- a/src/Intracto/SecretSantaBundle/Controller/PoolController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/PoolController.php
@@ -66,10 +66,12 @@ class PoolController extends Controller
                 }
                 $em = $this->getDoctrine()->getManager();
 
+                $dateFormatter = \IntlDateFormatter::create($request->getLocale(), \IntlDateFormatter::MEDIUM, \IntlDateFormatter::NONE);
+
                 $translator = $this->get('translator');
                 $message = $translator->trans('emails.created.message', array(
                     '%amount%' => $pool->getAmount(),
-                    '%date%' => $pool->getDate()->format("F jS"),
+                    '%date%' => $dateFormatter->format($pool->getDate()->getTimestamp()),
                     '%message%' => $pool->getMessage(),
                 ));
 

--- a/src/Intracto/SecretSantaBundle/Entity/Pool.php
+++ b/src/Intracto/SecretSantaBundle/Entity/Pool.php
@@ -82,6 +82,14 @@ class Pool
     private $created = false;
 
     /**
+     * @var string $locale
+     *
+     * @ORM\Column(name="locale", type="string", length=5)
+     *
+     */
+    private $locale = 'en';
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -333,5 +341,28 @@ class Pool
     public function getCreated()
     {
         return $this->created;
+    }
+
+    /**
+     * Set locale
+     *
+     * @param string $locale
+     * @return Pool
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+
+        return $this;
+    }
+
+    /**
+     * Get locale
+     *
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
     }
 }

--- a/src/Intracto/SecretSantaBundle/EventListener/LocaleListener.php
+++ b/src/Intracto/SecretSantaBundle/EventListener/LocaleListener.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Intracto\SecretSantaBundle\EventListener;
+
+use JMS\I18nRoutingBundle\Router\I18nRouter;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class LocaleListener implements EventSubscriberInterface
+{
+    /**
+     * @var array $availableLocals
+     */
+    private $availableLocals;
+
+    /**
+     * @var I18nRouter $router
+     */
+    private $router;
+
+    public function __construct($availableLocals, I18nRouter $router)
+    {
+        $this->availableLocals = $availableLocals;
+        $this->router = $router;
+    }
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+        $route = $request->get('_route');
+        //first request the cookie is empty. Gets auto set by I18nRouter
+        if ($request->cookies->get('hl')) {
+            return;
+        }
+        $preferredLocale = $request->getPreferredLanguage($this->availableLocals);
+        if ($preferredLocale && $request->attributes->get('_locale') != $preferredLocale) {
+            $url = $this->router->generate($route, ['_locale' => $preferredLocale] + $request->attributes->get('_route_params'));
+            $event->setResponse(new RedirectResponse($url));
+        }
+
+
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            // must be registered before the default Locale listener
+            KernelEvents::REQUEST => array(array('onKernelRequest', 17)),
+        );
+    }
+}

--- a/src/Intracto/SecretSantaBundle/EventListener/LocaleListener.php
+++ b/src/Intracto/SecretSantaBundle/EventListener/LocaleListener.php
@@ -30,13 +30,23 @@ class LocaleListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
         $route = $request->get('_route');
+        $locale = $request->get('_locale');
+        $route_params = $request->attributes->get('_route_params');
+
+        //menu locale switcher used?
+        if ($request->query->has('force-locale-switch')) {
+            $request->cookies->set('hl', $locale);
+            $url = $this->router->generate($route, ['_locale' => $locale] + $route_params);
+            $event->setResponse(new RedirectResponse($url));
+            return;
+        }
         //first request the cookie is empty. Gets auto set by I18nRouter
         if ($request->cookies->get('hl')) {
             return;
         }
         $preferredLocale = $request->getPreferredLanguage($this->availableLocals);
         if ($preferredLocale && $request->attributes->get('_locale') != $preferredLocale) {
-            $url = $this->router->generate($route, ['_locale' => $preferredLocale] + $request->attributes->get('_route_params'));
+            $url = $this->router->generate($route, ['_locale' => $preferredLocale] + $route_params);
             $event->setResponse(new RedirectResponse($url));
         }
 
@@ -47,7 +57,7 @@ class LocaleListener implements EventSubscriberInterface
     {
         return array(
             // must be registered before the default Locale listener
-            KernelEvents::REQUEST => array(array('onKernelRequest', 17)),
+            KernelEvents::REQUEST => array(array('onKernelRequest', 1)),
         );
     }
 }

--- a/src/Intracto/SecretSantaBundle/Form/ExcludeEntryType.php
+++ b/src/Intracto/SecretSantaBundle/Form/ExcludeEntryType.php
@@ -22,6 +22,8 @@ class ExcludeEntryType extends AbstractType
                 'multiple' => true,
                 'expanded' => false,
                 'property' => 'name',
+
+                /** @Ignore */
                 'label' => $me->getName(),
                 'attr' => array('data-entry' => $me->getId()),
                 'query_builder' => function (EntityRepository $er) use ($me) {
@@ -35,6 +37,7 @@ class ExcludeEntryType extends AbstractType
                 },
                 'required' => false,
             ));
+
         });
     }
 

--- a/src/Intracto/SecretSantaBundle/Form/PoolType.php
+++ b/src/Intracto/SecretSantaBundle/Form/PoolType.php
@@ -28,14 +28,14 @@ class PoolType extends AbstractType
               'genemu_jquerydate',
               array(
                   'widget' => 'single_text',
-                  'label' => 'Date of your Secret Santa party',
+                  'label' => 'label.date_party',
               )
           )
           ->add(
               'amount',
               'text',
               array(
-                  'label' => 'Amount to spend',
+                  'label' => 'label.amount_to_spend',
               )
           );
     }

--- a/src/Intracto/SecretSantaBundle/Resources/public/css/mediaqueries.css
+++ b/src/Intracto/SecretSantaBundle/Resources/public/css/mediaqueries.css
@@ -35,6 +35,10 @@
 			.footer-links {
 				padding: 0px;
 			}
+
+    #locale-menu {
+        right: 25px;
+    }
 }
 
 @media only screen and (max-width: 480px) {

--- a/src/Intracto/SecretSantaBundle/Resources/public/css/update.css
+++ b/src/Intracto/SecretSantaBundle/Resources/public/css/update.css
@@ -316,3 +316,17 @@ input.span12, textarea.span12, .uneditable-input.span12 {
 ul.form-errors {
     color: #A12C2C;
 }
+
+#locale-menu {
+    position: absolute;
+    list-style: none;
+    top: 0;
+    right: 365px;
+    padding: 0;
+    margin: 0;
+}
+
+#locale-menu li {
+    float: left;
+    padding: 2px 5px;
+}

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -174,6 +174,26 @@ btn:
     update_wishlist: Update your wishlist
 
 emails:
+    base:
+        title: Secret Santa by Intracto
+        footer: Have fun organizing Secret Santa!
+        created_by: Created by
+    pendingconfirmation:
+        salutation: Hi %name%
+        click_button: Please click on the button below to validate your Secret Santa mailing list.  This will trigger our gnomes to send out the personal message you created earlier to all your participants.
+        overview_page: On the newly created overview page you will then be able to keep track of all your users discovering their Secret Santa gift buddies. Thus knowing when the list is complete.
+        lastly: And lastly, don't forget to confirm your own participation as well! We'll also send you a new e-mail after you click the validation button below.
+        btn_validate: Validate my event
+        click_link: Please click on the link below to validate your Secret Santa mailing list.
+    secretsanta:
+        btn_find_out: Find out your person
+        link_find_out: Find out your randomly assigned person to give a gift to, on this url
+    wishlistchanged:
+        salutation: Hi %name%
+        buddy_updated_wishlist: Your buddy has updated his wishlist.
+        click_button: Click on the button below to check out his suggestions.
+        btn_check_wishlist: Check wishlist
+        click_link: Click on the link below to check out his suggestions.
     created:
         message: |
             Hi there (NAME),

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -1,0 +1,207 @@
+base:
+    meta:
+        description: Secret Santa Organizer is a free online Secret Santa gift exchange organizer! Organize a Secret Santa party with friends, family or even co-workers and add your wishlist.
+        title: Secret Santa Online gift exchange organizer!
+        og:
+            site_name: Secret Santa
+            description: Secret Santa Organizer is a free online Secret Santa gift exchange organizer! Organize a Secret Santa party with friends, family or even co-workers and add your wishlist.
+    nav:
+        home: Home
+    privacy_policy: Privacy policy
+    have_fun: Have fun organizing your Secret Santa!
+pool:
+    header:
+        steps:
+            title: Your gift exchange event <br/>in <span class="accent">3 easy steps</span>
+            list:
+                one: List your participants
+                two: Add a personal message
+                three: Send!
+            get_started: Get Started!
+
+create:
+    what_is:
+        title: What is Secret Santa?
+        intro: >
+                <p>It’s a <strong>free</strong> online Secret Santa <strong>gift exchange organizer</strong>! Organize a Secret
+                Santa party with friends, family or even co-workers. After receiving the Secret Santa mail you can add your
+                own <strong>wishlist</strong>, which will be delivered to your Secret Santa.</p>
+
+                <p>Each year around <strong>Christmas</strong> time people all over the world exchange gifts.<br/>
+                To keep things interesting though, you can <strong>randomly assign persons to each other</strong> to give a
+                present to one another.</p>
+
+    add_participants: Add your participants
+    list_adminstrator: This person is also your list administrator.
+    add_personal_message:
+        title: Add a personal message
+        description: Add a personal message for the participants.
+exclude:
+   title: Exclude
+created:
+    title: Only 1 step to go! - Validate your participation
+    body: >
+            <p>
+                To prevent bots or trolls to ruin the Secret Santa party, we need the list organizer <b>%ownername%</b> to validate his or her participation. We''ve sent a mail to <b>%owneremail%</b> with further instructions.
+            </p>
+            <p>
+                Once validated, your Secret Santa list will be scrambled and all users will receive your message along with the name of their Secret Santa gift buddy.
+            </p>
+            <p>
+                In the validation e-mail the list organizer will also find a link to keep track of all users in their Secret Santa list who''ve already found out their gift buddy. Making sure every Secret Santa knows his duty.
+            </p>
+    warning: Warning!
+    check_spam: Don't forget to check your spam folder!
+
+deleted:
+    title: Your Secret Santa list was deleted!
+    body: >
+        <p>Thank you for using Secret Santa Organizer. And, we hope to see you again next year!</p>
+
+manage:
+    title: Your Secret Santa list
+    yes: Yes
+    not_yet: Not yet
+    edit_email: Edit e-mail
+    resend_email: Resend e-mail
+    view_entry: View entry
+    tip: Tip
+    come_back: You can always come back to this page to make sure everybody has checked his or her mailbox.
+    save: Save
+
+delete:
+    title: Delete my Secret Santa list
+    body: >
+        <p>
+            Are you ABSOLUTELY sure?<br>
+            <br>
+            <b>Unexpected bad things will happen if you don't read this!</b><br>
+            <br>
+            Once you delete your Secret Santa list, there is no going back. This action CANNOT be undone.<br>
+            This will delete this Secret Santa list, all it's participants and their wishlists permanently.<br>
+            <br>
+            Please type "<b>%pharse_to_type%</b>" below to confirm.<br>
+        </p>
+    pharse_to_type: delete everything
+entry:
+    headers:
+        title: Your <span class="accent">Secret Santa party</span> details
+        date: Date
+        amount: Amount
+        num_people: Number of people
+        person_created_list: Person who created this list
+    title: Your assigned buddy
+    body: >
+        <p>Hi %name%,</p>
+        <p>You are assigned as Secret Santa to give a present to:</p>
+    wishlist_from: Wishlist from %name%
+    wishlist_not_provided: %name% has not yet provided a wishlist
+    wishlist:
+        title: Your wishlist
+        description: To help your Secret Santa, you can leave a wishlist here. Our gnomes will take care of communicating this to your Secret Santa. You can re-order the list by dragging the items in place.
+    wishlist_empty: Your wishlist is empty. Add something!
+
+static:
+    privacy_policy:
+        title: Privacy Policy
+        body: >
+            <p>Thank you for visiting secretsantaorganizer.com created by Intracto group NV. This privacy policy tells you
+                how we use personal information collected at this site. Please read this privacy policy before using the
+                site or submitting any personal information. By using the site, you are accepting the practices described in
+                this privacy policy. These practices may be changed, but any changes will be posted and changes will only
+                apply to activities and information on a going forward, not retroactive basis. You are encouraged to review
+                the privacy policy whenever you visit the site to make sure that you understand how any personal information
+                you provide will be used.</p>
+
+            <p>Note: the privacy practices set forth in this privacy policy are for this web site only. If you link to other
+                web sites, please review the privacy policies posted at those sites.</p>
+
+            <h2>Collection of Information</h2>
+
+            <p>We collect personally identifiable information, like names and email addresses, when voluntarily submitted by
+                our visitors. The information you provide is used to fulfill your specific request.</p>
+
+            <h2>Cookie/Tracking Technology</h2>
+
+            <p>This site uses cookies present in Google Analytics for gathering anonymous information such as browser type
+                and operating system, tracking the number of visitors to the site, and understanding how visitors use the
+                site. Personal information cannot be collected via cookies and other tracking technology.</p>
+
+            <p>You can turn off the use of cookies in the settings of your browser.</p>
+
+            <h2>Distribution of Information</h2>
+
+            <p>We may share information with governmental agencies or other companies assisting us in fraud prevention or
+                investigation. We may do so when: (1) permitted or required by law; or, (2) trying to protect against or
+                prevent actual or potential fraud or unauthorized transactions; or, (3) investigating fraud which has
+                already taken place. The information is not provided to these companies for marketing purposes.</p>
+
+            <h2>Commitment to Data Security</h2>
+
+            <p>Your personally identifiable information is kept secure. Only authorized employees, agents and contractors
+                (who have agreed to keep information secure and confidential) have access to this information. All emails
+                from this site are unique to your specific request. No recurring emails or newsletters will be sent to the
+                email addresses provided.</p>
+
+            <h2>Privacy Contact Information</h2>
+
+            <p>If you have any questions, concerns, or comments about our privacy policy you may contact us using the
+                information below:<br/>
+                By e-mail: info@secretsantaorganizer.com</p>
+
+            <p>We reserve the right to make changes to this policy. Any changes to this policy will be posted.</p>
+
+label:
+    name: Name
+    email: E-mail
+    date_party: Date of your Secret Santa party
+    amount_to_spend: Amount to spend
+    exclude: Exclude
+    confirmed: Confirmed
+    actions: Actions
+    description: Description
+placeholder:
+    exclude: Click and choose the participants you want to exclude
+btn:
+    add_person: Add person
+    remove_person: Remove this person
+    create_event: Create your event!
+    create_new_list: Create a new Secret Santa list!
+    delete_list: Delete my Secret Santa list
+    delete_confirm: I understand the consequences, delete my Secret Santa list now
+    add_wishlist: Add item to wishlist
+    remove_item: Remove this item
+    update_wishlist: Update your wishlist
+
+emails:
+    created:
+        message: |
+            Hi there (NAME),
+
+            (ADMINISTRATOR) created a Secret Santa event and has listed you as a participant.
+
+            Join the Secret Santa fun and find out who your gift buddy is by clicking the button below.
+
+            You can spend up to %amount% for your gift. But of course creating your own present is allowed. Even encouraged!
+
+            The Secret Santa party is planned %date%. Be sure to bring your gift!
+
+            %message%
+
+
+            Happy Holidays!
+flashes:
+    manage:
+        email_validated: >
+         <strong>Perfect!</strong><br/>Your email is now validated.<br/>
+         Our gnomes are travelling on the internet as we speak, delivering all your soon-to-be-Secret-Santas their gift buddies.<br/>
+         <br />
+         Don't forget to confirm your own participation. We've sent you another email. Go check it out!
+    delete:
+        not_deleted: <h4>Not deleted</h4> The confirmation was incorrect.
+    resend:
+        resent: <strong>Resent!</strong><br/>The e-mail to %email% has been resent.<br/>
+    entry:
+        wishlist_updated: <h4>Wishlist updated</h4>We've sent out our gnomes to notify your Secret Santa about your wishes!
+        edit_email: <h4>Not saved</h4> There is an error in the email address.
+        saved_email: <h4>Saved</h4> The new email address was saved. We also resent the e-mail.

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -3,6 +3,7 @@ base:
         description: Secret Santa Organizer is a free online Secret Santa gift exchange organizer! Organize a Secret Santa party with friends, family or even co-workers and add your wishlist.
         title: Secret Santa Online gift exchange organizer!
         og:
+            title: Secret Santa
             site_name: Secret Santa
             description: Secret Santa Organizer is a free online Secret Santa gift exchange organizer! Organize a Secret Santa party with friends, family or even co-workers and add your wishlist.
     nav:
@@ -80,9 +81,9 @@ delete:
             Once you delete your Secret Santa list, there is no going back. This action CANNOT be undone.<br>
             This will delete this Secret Santa list, all it's participants and their wishlists permanently.<br>
             <br>
-            Please type "<b>%pharse_to_type%</b>" below to confirm.<br>
+            Please type "<b>%phrase_to_type%</b>" below to confirm.<br>
         </p>
-    pharse_to_type: delete everything
+    phrase_to_type: delete everything
 entry:
     headers:
         title: Your <span class="accent">Secret Santa party</span> details
@@ -192,6 +193,7 @@ emails:
         btn_find_out: Find out your person
         link_find_out: Find out your randomly assigned person to give a gift to, on this url
     wishlistchanged:
+        subject: Wishlist updated
         salutation: Hi %name%
         buddy_updated_wishlist: Your buddy has updated his wishlist.
         click_button: Click on the button below to check out his suggestions.

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -174,11 +174,13 @@ btn:
     update_wishlist: Update your wishlist
 
 emails:
+    sender: Santa Claus
     base:
         title: Secret Santa by Intracto
         footer: Have fun organizing Secret Santa!
         created_by: Created by
     pendingconfirmation:
+        subject: Secret Santa Validation
         salutation: Hi %name%
         click_button: Please click on the button below to validate your Secret Santa mailing list.  This will trigger our gnomes to send out the personal message you created earlier to all your participants.
         overview_page: On the newly created overview page you will then be able to keep track of all your users discovering their Secret Santa gift buddies. Thus knowing when the list is complete.
@@ -186,6 +188,7 @@ emails:
         btn_validate: Validate my event
         click_link: Please click on the link below to validate your Secret Santa mailing list.
     secretsanta:
+        subject: Your SecretSanta
         btn_find_out: Find out your person
         link_find_out: Find out your randomly assigned person to give a gift to, on this url
     wishlistchanged:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
@@ -1,0 +1,209 @@
+base:
+    meta:
+        description: Secret Santa Organizer est un organiseur en ligne gratuit d'échange de cadeaux ! Organisez une Secret Santa party avec vos amis et publiez vos souhaits.
+        title: Secret Santa Organizer - Echange de cadeaux en ligne!
+        og:
+            title: Secret Santa
+            site_name: Secret Santa
+            description: Secret Santa Organizer est un organiseur en ligne gratuit d'échange de cadeaux ! Organisez une Secret Santa party avec vos amis et publiez vos souhaits.
+    nav:
+        home: Accueil
+    privacy_policy: Protection vie privée
+    have_fun: Amusez-vous en créant votre Secret Santa!
+pool:
+    header:
+        steps:
+            title: Votre événement d'échange de cadeaux en <span class="accent">3 étapes</span>
+            list:
+                one: Inscrivez vos particpants
+                two: Ajoutez un message personnel
+                three: Envoyez!
+            get_started: Commencer!
+
+create:
+    what_is:
+        title: Qu'est-ce que Secret Santa?
+        intro: >
+            <p>Secret Santa Organizer est un organiseur en ligne <strong>gratuit d'échange de cadeaux</strong>  ! Organisez une Secret Santa party avec vos amis, votre famille ou vos collègues. Après avoir reçu l'e-mail de Secret Santa, vous pourrez ajouter votre propre <strong>liste de souhaits</strong>, qui sera ensuite délivrée à votre Père-Noël secret</p>
+
+            <p>Chaque année, autour de la période de <strong>Noël</strong>, les gens du monde entier s'échangent des cadeaux.<br/>Afin de garder les choses intéressantes, vous pouvez assigner au hasard une personne à une autre afin qu'elles offrent un présent aux autres.</p>
+
+    add_participants: Ajoutez les participants
+    list_adminstrator: Cette personne est également l'administrateur.
+    add_personal_message:
+        title: Ajoutez un message personnel
+        description: Ajoutez un message personnel pour les participant.
+exclude:
+   title: Exclure
+created:
+    title: Plus qu'une étape ! - Validez votre participation
+    body: >
+            <p>
+               Afin de se prémunir des robots ou des trolls qui pourraient gâcher le secret, nous avons besoin que l'organisateur <b>%ownername%</b> confirme sa participation. Nous venons d'envoyer un e-mail à <b>%owneremail%</b> avec les instructions nécessaires.
+            </p>
+            <p>
+                Une fois validée, votre liste Secret Santa sera brouillée et chaque partipant recevra votre message avec le nom de la personne à qui offrir un cadeau.
+            </p>
+            <p>
+                Dans l'e-mail de confirmation, l'organisateur trouvera également un lien qui lui permettra de savoir qui a déjà trouvé son ami cadeau. Assurez-vous que chaque Père-Noël secret soit au courant.
+            </p>
+    warning: Attention !
+    check_spam: N'oubliez pas de vérifier votre dossier Spam !
+
+deleted:
+    title: Votre liste Secret Santa a été supprimée !
+    body: >
+        <p>Merci d'avoir utilisé Secret Santa Organize. Et nous espérons vous revoir l'année prochaine !</p>
+
+manage:
+    title: Votre liste Secret Santa
+    yes: Oui
+    not_yet: Pas encore
+    edit_email: Modifier l'e-mail
+    resend_email: Renvoyer l'e-mail
+    view_entry: Voir l'entrée
+    tip: Astuce
+    come_back: Vous pouvez toujours revenir sur cette page afin de vous assurer que tout le monde ait vérifié sa boîte mail.
+    save: Enregistrer
+
+delete:
+    title: Supprimer ma liste Secret Santa
+    body: >
+        <p>
+        Etes-vous vraiment certain?<br>
+        <br>
+        <b>Quelque chose d'inattendu se produira si vous ne lisez pas ceci !</b><br>
+        <br>
+        Une fois que votre liste Secret Santa sera supprimée, il n'y a aucun retour en arrière possible. Cette action NE POURRA PAS être annulée.<br>
+        Cela effacera la liste Secret Santa, tous ses participants ainsi que leur liste de souhaits de façon permanente.<br>
+        <br>
+        Entrez svp "<b>%phrase_to_type%</b>" ci-dessous afin de confirmer.<br></p>
+    phrase_to_type: Supprimer tout
+entry:
+    headers:
+        title: Détails de votre <span class="accent">Secret Santa party</span>
+        date: Date
+        amount: Montant
+        num_people: Nombre de personnes
+        person_created_list: Créateur de la liste
+    title: Personne désignée
+    body: >
+        <p>Bonjour %name%,</p>
+        <p>En tant que Père-Noël Secret, vous devez distribuer un cadeau à:</p>
+    wishlist_from: Liste de souhaits de %name%
+    wishlist_not_provided: %name% n'a pas encore publié de liste de souhaits
+    wishlist:
+        title: Votre liste de souhaits
+        description: Afin d'aider votre Père-Noël Secret, vous pouvez laisser une liste de souhaits ici. Nos gnomes prendront soin de la communiquer à votre Père-Noël Secret. Vous pouvez réorganiser la liste en faisant glisser les éléments.
+    wishlist_empty: Votre liste de souhaits est vide. Ajoutez quelque chose !
+
+static:
+    privacy_policy:
+        title: Protection vie privée
+        body: >
+            <p>Merci de visiter secretsantaorganizer.com créé par Intracto group NV. Cette politique de confidentialité vous informe sur la manière dont nous utilisons les données personnelles collectées sur ce site. Merci de bien vouloir lire notre politique de confidentialité avant d'utiliser ce site ou d'envoyer toute information personnelle. En utilisant ce site, vous acceptez les conditions décrites dans ce document. Ces conditions peuvent être modifiées, mais chaque modification sera affichée et les changements concerneront seulement l'activité et des informations sur un changement futur, et non de manière rétroactive. Nous vous encourageons à vérifier notre politique de confidentialité lors de chaque visite sur le site afin de comprendre exactement comment sont utilisées les données personnelles que vous fournissez.</p>
+
+            <p>Note: La politique de confidentialité décrite ci-dessous concerne uniquement ce site Internet. Si vous accédez à un autre site Internet, merci de bien vouloir consulter la politique de confidentialité présente sur ces sites.</p>
+
+            <h2>Collecte d'information</h2>
+
+            <p>Nous collectons des données personnelles identifiables, comme les noms ou adresses e-mails lorsqu'elles sont soumisent volontairement par nos visiteurs. Les informations fournies sont utilisées dans le but de répondre à une demande spécifique de votre part.</p>
+
+            <h2>Cookies/Suivi</h2>
+
+            <p>Ce site utilise des cookies afin de fournir des informations à Google Analytics de manière anonyme. Ces informations peuvent être: le type de navigateur utilisé, le système d'exploitation, le nombre de visiteurs et la façon dont l'internaute utilise le site.</p>
+
+            <p>Vous pouvez désactiver l'utilisation des cookies dans les paramètres de votre navigateur</p>
+
+            <h2>Partage de l'information</h2>
+
+            <p>Nous pouvons partager les informations avec des agences gouvernementales ou d'autres sociétés nous aidant à luter contre la fraude ou menant une enquête. Nous le faisons lorsque: (1)c'est permis ou requis par la loi; ou, (2)il y a suspicion de fraude réelle ou potentionelle, ou des transactions non autorisées, ou (3)une enquête est ouverte concernant une fraude. Ces données ne sont pas fournies à ces sociétés à des fins de marketing.</p>
+
+            <h2>Sécurité des données</h2>
+
+            <p>Vos données personnelles sont maintenues en sécurité. Seuls les employés, agents et sous-traitants (qui ont accepté de garder les données confidentielles et de manière sécurisée) ont accès à ces informations. Tous les e-mails envoyés depuis ce site répondent à une demande spécifique de votre part. Aucun e-mail non sollicité ou newsletter ne sera envoyé vers ces adresses.</p>
+
+            <h2>Confidentialité de vos coordonnées</h2>
+
+            <p>Pour toute question, ou commententaire concernant notre politique de confidentialité, vous pouvez nous contacter via:<br/> e-mail: info@secretsantaorganizer.com</p>
+
+            <p>Nous nous réservons le droit d'apporter des changements à notre politique de confidentialités. Tout changement sera notifié</p>
+
+label:
+    name: Nom
+    email: E-mail
+    date_party: Date de votre Secret Santa party
+    amount_to_spend: Montant à dépenser
+    exclude: Exclure
+    confirmed: Confirmés
+    actions: Actions
+    description: Déscription
+placeholder:
+    exclude: Cliquez et sélectionnez les partipants que vous désirez exclure
+btn:
+    add_person: Ajouter une personne
+    remove_person: Supprimer cette personnel
+    create_event: Créer votre événement
+    create_new_list: Créer une nouvelle liste Secret Santa !
+    delete_list: Supprimer ma liste Secret Santa
+    delete_confirm: J'ai compris les conséquences, supprimer ma liste Secret Santa maintenant
+    add_wishlist: Ajouter un objet à ma liste de souhaits
+    remove_item: Supprimer cet objet
+    update_wishlist: Mettre à jour votre liste de souhaits
+
+emails:
+    sender: Santa Claus
+    base:
+        title: Secret Santa par Intracto
+        footer: Have fun organizing Secret Santa!
+        created_by: Créé par
+    pendingconfirmation:
+        subject: Confirmation Secret Santa
+        salutation: Bonjour %name%
+        click_button: Merci de bien vouloir cliquer sur le bouton ci-dessous afin de valider votre liste de diffusion Secret Santa. Cela réveillera nos gnomes afin qu'ils envoient le message personnel que vous avez créé précédemment à tous les participants.
+        overview_page: Sur la page de présentation nouvellement créée, vous serez en mesure de garder une trace de tous les utilisateurs découvrant leur ami cadeau Secret Santa. Mais aussi d'être informé lorsque la liste est complète.
+        lastly: Et enfin, n'oubliez pas de confirmer votre propre participation ! Nous vous enverrons également un nouvel e-mail lorsque vous aurez cliqué sur le bouton de validation ci-dessous.
+        btn_validate: Valider mon événement
+        click_link: Merci de bien vouloir cliquer sur le lien ci-dessous afin de valider votre liste de diffusion Secret Santa
+    secretsanta:
+        subject: Votre Secret Santa
+        btn_find_out: Découvrez votre personne
+        link_find_out: Découvrez la personne qui vous a été attribuée au hasard et à qui vous devez offrir un cadeau, à cette adresse
+    wishlistchanged:
+        subject: Liste de souhaits mise à jour
+        salutation: Bonjour %name%
+        buddy_updated_wishlist: Votre ami a mis à jour sa liste de souhaits.
+        click_button: Cliquez sur le boutton ci-dessous afin de découvrir ses suggestions
+        btn_check_wishlist: Découvrir la liste de souhaits
+        click_link: Cliquez sur le boutton ci-dessous afin de découvrir ses suggestions
+    created:
+        message: |
+            Bonjour (NAME),
+
+            (ADMINISTRATOR) a créé un événement Secret Santa et vous a ajouté comme participant.
+
+            Rejoignez le jeu Secret Santa et découvrez la personne a qui vous devrez offrir un cadeau en cliquant sur le bouton ci-dessous
+
+            Pouvez dépenser jusqu'à %amount% pour votre cadeau. Mais bien sûr, créer votre cadeau est permis. C'est même vivement recommandé !
+
+            La Secret Santa party est prévue le %date%. Assurez-vous d'amener votre cadeau.
+
+            %message%
+
+
+            Bonnes vacances !
+flashes:
+    manage:
+        email_validated: >
+         <strong>Parfait !</strong><br/>Votre e-mail est maintenant validé<br/>
+         En ce moment, nos gnomes voyagent à travers l'Internet, afin de communiquer aux Pères-Noël secrets leur ami cadeau.<br/>
+         <br />
+         N'oubliez pas de confirmer votre participation. Nous vous avons envoyé un nouvel e-mail. Allez vérifier !
+    delete:
+        not_deleted: <h4>Non supprimée</h4> La confirmation était incorrect.
+    resend:
+        resent: <strong>Renvoyé !</strong><br/>L'e-mail à %email% a bien été renvoyé.<br/>
+    entry:
+        wishlist_updated: <h4>Liste de souhaits mise à jour</h4>Nous avons envoyé nos gnomes afin qu'ils avertissent votre Père-Noël secret de vos souhaits !
+        edit_email: <h4>Non enregistrée</h4> Il y a une erreur dans l'adresse e-mail.
+        saved_email: <h4>Enregistrée</h4> La nouvelle adresse e-mail a été enregistrée. Nous avons également renvoyé l'e-mail.

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -13,7 +13,7 @@ base:
 pool:
     header:
         steps:
-            title: Jouw geschenkuitwisselings- <br>evenement in <span class="accent">3 eenvoudige stappen</span>
+            title: Jouw geschenkuitwisselings- <br>evenement <small>in <span class="accent">3 eenvoudige stappen</span></small>
             list:
                 one: Stel je deelnemerslijst samen
                 two: Voeg een persoonlijke boodschap toe

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -1,0 +1,215 @@
+base:
+    meta:
+        description: Regel gratis je geschenkuitwisseling online met Secret Santa Organizer! Geen gedoe meer met 'namen trekken'. Stuur je verlanglijstje naar vrienden, familie,..
+        title: Secret Santa Online geschenkuitwisselings organizer!
+        og:
+            title: Secret Santa
+            site_name: Secret Santa
+            description: Regel gratis je geschenkuitwisseling online met Secret Santa Organizer! Geen gedoe meer met 'namen trekken'. Stuur je verlanglijst naar vrienden, familie,..
+    nav:
+        home: Home
+    privacy_policy: Privacy policy
+    have_fun: Organiseer je eigen Secret Santa en amuseer je rot!
+pool:
+    header:
+        steps:
+            title: Jouw geschenkuitwisselings- <br>evenement in <span class="accent">3 eenvoudige stappen</span>
+            list:
+                one: Stel je deelnemerslijst samen
+                two: Voeg een persoonlijke boodschap toe
+                three: Verstuur!
+            get_started: Vlieg er meteen in!
+
+create:
+    what_is:
+        title: Wat is Secret Santa?
+        intro: >
+                <p>Het is een <strong>gratis</strong> online Secret Santa <strong>geschenkuitwisselings organizer</strong>! Organiseer een Secret
+                Santa party met vrienden, familie of zelfs collega''s. Nadat je een mailtje hebt ontvangen van Secret Santa Organizer,
+                kan je je eigen <strong>verlanglijst</strong> toevoegen, die sturen wij dan door naar jouw Secret Santa.</p>
+
+                <p>Ieder jaar wisselen mensen tijdens de kerstperiode wereldwijd geschenken uit.<br/> Om het voor iedereen wat spannender te maken, kan je mensen <strong>willekeurig toewijzen</strong> om voor elkaar geschenkjes te kopen.</p>
+
+    add_participants: Voeg je deelnemers toe
+    list_adminstrator: Deze persoon is ook jouw lijstbeheerder
+    add_personal_message:
+        title: Voeg een persoonlijke boodschap toe
+        description: Voeg een persoonlijke boodschap voor de deelnemers toe
+exclude:
+   title: Uitsluiten
+created:
+    title: Nog 1 stapje te gaan! - Valideer je deelname
+    body: >
+            <p>
+                Om te voorkomen dat ongewenste gasten je Secret Santa party verknallen, moet lijstbeheerder <b>%ownername%</b> iedere deelname valideren. We hebben <b>%owneremail%</b> een mailtje gestuurd met verdere instructies.
+            </p>
+            <p>Eens de deelnemerslijst is goedgekeurd, wordt hij door elkaar gegooid en krijgen alle gebruikers jouw boodschap en de naam van de persoon voor wie ze een geschenk moeten kopen.
+            </p>
+            <p>
+                In de validatiemail vindt de lijstbeheerder ook een link om iedereen die al weet voor wie hij of zij iets moet kopen op te volgen. Zo weet de organisator zeker dat iedere Secret Santa zich van zijn zware taak bewust is.</p>
+    warning: Let op!
+    check_spam: Vergeet je spamfolder niet te checken!
+
+deleted:
+    title: Je Secret Santa lijst werd verwijderd!
+    body: >
+        <p>Bedankt voor het gebruik van de Secret Santa Organizer. Tot volgend jaar! </p>
+
+manage:
+    title: Jouw Secret Santa lijst
+    yes: Ja
+    not_yet: Nog niet
+    edit_email: E-mail aanpassen
+    resend_email: E-mail nogmaals verzenden
+    view_entry: Deelnemer bekijken
+    tip: Tip
+    come_back: Je kan altijd terugkeren naar deze pagina om te kijken of iedereen zijn of haar mailbox heeft gecheckt.
+    save: Bewaar
+
+delete:
+    title: Verwijder mijn Secret Santa lijst
+    body: >
+        <p>
+        Ben je HELEMAAL zeker?<br>
+        <br>
+        <b>De zeven plagen hangen in de lucht als je dit niet leest!</b><br>
+        <br>
+        Eens je jouw Secret Santa lijst verwijderd hebt, mag je er een kruis over maken. Je KAN DEZE ACTIE NIET ongedaan maken. <br>
+
+        Je Secret Santa lijst wordt permanent verwijderd, samen met alle deelnemers en hun droomgeschenken.<br>
+
+        <br>Typ "<b>%phrase_to_type%</b>" onderaan om te bevestigen.<br>
+        </p>
+    phrase_to_type: alles verwijderen
+entry:
+    headers:
+        title: Jouw <span class="accent">Secret Santa party</span> details
+        date: Datum
+        amount: Bedrag
+        num_people: Aantal mensen
+        person_created_list: Persoon die deze lijst samenstelde
+    title: Jouw toegewezen maatje
+    body: >
+        <p>Hey %name%,</p>
+        <p>Je bent toegewezen als Secret Santa aan:</p>
+    wishlist_from: Verlanglijst van %name%
+    wishlist_not_provided: %name% heeft nog geen verlanglijst opgesteld
+    wishlist:
+        title: Jouw verlanglijstje
+        description: Om je Secret Santa een handje te helpen, kan je jouw verlanglijst hier opstellen. Onze kaboutertjes zullen je zware lijst tot bij hem of haar brengen. Je kan de lijst opnieuw sorteren door items te verslepen.
+    wishlist_empty: Je verlanglijst is leeg. Voeg iets toe!
+
+static:
+    privacy_policy:
+        title: Privacybeleid
+        body: >
+            <p>Bedankt voor je bezoek aan secretsantaorganizer.com, gerealiseerd door Intracto group NV. Dit privacybeleid beschrijft hoe we op deze website persoonlijke informatie verzamelen. Lees dit privacybeleid zorgvuldig vooraleer je de website gebruikt of persoonlijke informatie achterlaat. Door deze website te gebruiken, accepteer je de regels die in dit privacybeleid beschreven staan.
+            Deze regels zijn onderhevig aan veranderingen, maar deze veranderingen worden gepubliceerd en zijn enkel van toepassing op toekomstig activiteiten en informatie en zijn dus niet met terugwerkende kracht. We moedigen aan het privacybeleid bij ieder bezoek aan de website te herlezen om je ervan te verzekeren dat je gebruikt hoe door jou ingegeven persoonlijke informatie wordt gebruikt.<p>
+
+            <p>Toelichting: De privacyregels die in dit privacybeleid beschreven staan zijn enkel van toepassing op deze website. Link je naar andere websites, lees dan het privacybeleid van de respectievelijke websites.<p>
+
+            <h2>Verzameling van informatie</h2>
+
+            <p>We verzamelen persoonlijk identificeerbare informatie als namen en e-mailadressen, wanneer vrijwillig ingegeven door onze bezoekers. De informatie die je verstrekt wordt gebruikt om je eigen specifieke aanvraag uit te voeren. 
+            </p>
+
+            <h2>Cookie/Tracking Technologie</h2>
+
+            <p>Deze website gebruikt cookies aanwezig in Google Analytics voor het verzamelen van anonieme informatie zoals je type browser en besturingssysteem, het tracken van bezoekersaantallen op de website en het begrijpen van gebruikersgedrag. Persoonlijke informatie kan niet via cookies en andere trackingtechnology verzameld worden.</p>
+
+            <p>Je kan het gebruik van cookies uitschakelen in de instellingen van je browser.</p>
+
+            <h2>Informatieverspreiding</h2>
+
+            <p>Mogelijk delen we informatie met overheidsagentschappen of andere bedrijven die ons bijstaan in onderzoek naar of preventie van fraude. 
+            Dit kunnen we doen wanneer: (1) toegestaan of verplicht bij wet; of, (2) we jou en onszelf proberen te beschermen tegen feitelijke of potenti�le fraude of ongeautoriseerde transacties; of, (3) we fraude die al heeft plaatsgevonden onderzoeken. De informatie wordt niet voor commerci�le doeleinden aan deze bedrijven doorgegeven.</p>
+
+            <h2>Inspanningen voor gegevensbescherming</h2>
+
+            <p>Jouw persoonlijk identificeerbare informatie wordt veilig bewaard. Enkel bevoegde werknemers, vertegenwoordigers en uitvoerders (die zich akkoord hebben verklaard informatie veilig en vertrouwelijk te houden) hebben toegang tot deze informatie. Alle e-mails van deze website zijn komen louter tegemoet aan jouw specifieke aanvraag. Er worden geen terugkerende e-mails of nieuwsbrieven naar de verstrekte e-mailadressen verstuurd.</p>
+
+            <h2>Privacy contactinformatie</h2>
+
+            <p>Heb je vragen, bezorgdheden of opmerkingen over ons privacybeleid, contacteer ons dan aan de hand van onderstaande informatie:<br/>
+            Via e-mail: info@secretsantaorganizer.com</p>
+
+            <p>We behouden het recht om dit beleid te wijzigen. Alle wijzigingen aan dit beleid worden gepubliceerd.</p>
+
+label:
+    name: Naam
+    email: E-mail
+    date_party: Datum van jouw Secret Santa party
+    amount_to_spend: Te spenderen bedrag
+    exclude: Uitsluiten
+    confirmed: Bevestigd
+    actions: Acties
+    description: Beschrijving
+placeholder:
+    exclude: Klik en kies de deelnemers die je wilt uitsluiten
+btn:
+    add_person: Persoon toevoegen
+    remove_person: Deze persoon verwijderen
+    create_event: Maak je evenement aan!
+    create_new_list: Stel een nieuwe Secret Santa lijst op!
+    delete_list: Verwijder mijn Secret Santa lijst
+    delete_confirm: Ik begrijp de gevolgen, verwijder nu mijn Secret Santa lijst
+    add_wishlist: Voeg item toe aan verlanglijst
+    remove_item: Verwijder dit item
+    update_wishlist: Update je verlanglijst
+
+emails:
+    sender: Kerstman
+    base:
+        title: Secret Santa door Intracto
+        footer: Veel plezier met het organiseren van Secret Santa! 
+        created_by: Aangemaakt door
+    pendingconfirmation:
+        subject: Secret Santa Validatie
+        salutation: Hey %name%
+        click_button: Klik op onderstaande knop om je Secret Santa mailinglijst te valideren. Dan krijgen onze kaboutertjes automatisch een emmer water in hun gezicht gegooid. Als ze wakker zijn brengen ze jouw eerder opgestelde persoonlijke boodschap tot bij alle deelnemers.
+        overview_page: Op de net aangemaakte overzichtspagina kan je dan op de hoogte blijven van welke gebruikers al te weten zijn gekomen voor wie ze Secret Santa mogen spelen. Zo weet je wanneer je lijst volledig is.
+        lastly: En als laatste, vergeet je eigen deelname niet te bevestigen! Dat zou een beetje dom zijn, niet? We sturen je ook een nieuwe e-mail nadat je op onderstaande bevestigingsknop hebt geklikt.
+        btn_validate: Valideer mijn evenement
+        click_link: Klik op onderstaande link om je Secret Santa mailinglijst te bevestigen.
+    secretsanta:
+        subject: Jouw SecretSanta
+        btn_find_out: Ontdek wiens Secret Santa je bent
+        link_find_out: Ontdek je willekeurig geselecteerde persoon aan wie je een cadeau geeft via deze url
+    wishlistchanged:
+        subject: Verlanglijst geüpdatet
+        salutation: Hey %name%
+        buddy_updated_wishlist: Je persoon heeft zijn of haar verlanglijst geüpdatet.
+        click_button: Klik op onderstaande knop om zijn of haar suggesties te bekijken. 
+        btn_check_wishlist: Bekijk verlanglijst
+        click_link: Klik op onderstaande link om zijn of haar suggesties te bekijken. 
+    created:
+        message: |
+            Hey (NAME),
+
+            (ADMINISTRATOR) heeft een Secret Santa evenement gecreëerd en heeft jou als deelnemer opgegeven.
+
+            Amuseer je te pletter met Secret Santa en ontdek wiens Secret Santa je bent door op onderstaande knop te klikken.
+
+            Je mag tot %amount% aan je cadeau spenderen. Maar wees niet bevreesd cheapo's, eigen geschenken maken is toegestaan. We moedigen het zelfs aan!
+
+            Het Secret Santa feestje vindt plaats op %date%. Vergeet je cadeau niet!
+
+            %message%
+
+
+            Geniet van de feestdagen!
+flashes:
+    manage:
+        email_validated: >
+         <strong>Perfect!</strong><br/>Je e-mail is nu gevalideerd.<br/>
+         Onze kaboutertjes wurmen zich op dit eigenste moment doorheen het netwerk om al je toekomstige Secret Santa?s een persoon te bezorgen.<br/>
+         <br />
+         Vergeet je eigen deelname niet te bevestigen. We hebben je nog een e-mail gestuurd. Lees 'em snel!
+    delete:
+        not_deleted: <h4>Niet verwijderd</h4> De bevestiging verliep foutief.
+    resend:
+        resent: <strong>Opnieuw verstuurd!</strong><br/>De e-mail aan %email% werd opnieuw verstuurd.<br/>
+    entry:
+        wishlist_updated: <h4>Verlanglijst geüpdatet</h4>We hebben onze kaboutertjes op pad gestuurd om jouw Secret Santa te vertellen op welke cadeau's je vurig hoopt!
+        edit_email: <h4>Niet bewaard</h4> Er is wat fout met het e-mailadres. 
+        saved_email: <h4>Bewaard</h4> Het nieuwe e-mailadres werd bewaard. We hebben ook de e-mail opnieuw verstuurd.

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -122,7 +122,7 @@ static:
             <h2>Informatieverspreiding</h2>
 
             <p>Mogelijk delen we informatie met overheidsagentschappen of andere bedrijven die ons bijstaan in onderzoek naar of preventie van fraude. 
-            Dit kunnen we doen wanneer: (1) toegestaan of verplicht bij wet; of, (2) we jou en onszelf proberen te beschermen tegen feitelijke of potenti�le fraude of ongeautoriseerde transacties; of, (3) we fraude die al heeft plaatsgevonden onderzoeken. De informatie wordt niet voor commerci�le doeleinden aan deze bedrijven doorgegeven.</p>
+            Dit kunnen we doen wanneer: (1) toegestaan of verplicht bij wet; of, (2) we jou en onszelf proberen te beschermen tegen feitelijke of potentiële fraude of ongeautoriseerde transacties; of, (3) we fraude die al heeft plaatsgevonden onderzoeken. De informatie wordt niet voor commerciële doeleinden aan deze bedrijven doorgegeven.</p>
 
             <h2>Inspanningen voor gegevensbescherming</h2>
 

--- a/src/Intracto/SecretSantaBundle/Resources/translations/validators.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/validators.en.yml
@@ -1,0 +1,4 @@
+pool:
+    non_unique: Not all entries have an unique match.
+entry:
+    non_unique: No unique match found for "%name%

--- a/src/Intracto/SecretSantaBundle/Resources/translations/validators.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/validators.en.yml
@@ -1,4 +1,4 @@
 pool:
     non_unique: Not all entries have an unique match.
 entry:
-    non_unique: No unique match found for "%name%
+    non_unique: No unique match found for "%name%"

--- a/src/Intracto/SecretSantaBundle/Resources/translations/validators.fr.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/validators.fr.yml
@@ -1,0 +1,4 @@
+pool:
+    non_unique: Chaque entrée ne dispose pas d'une correspondance unique
+entry:
+    non_unique: Aucune correspondance unique trouv&eacute;e pour "%name%"

--- a/src/Intracto/SecretSantaBundle/Resources/translations/validators.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/validators.nl.yml
@@ -1,0 +1,1 @@
+pool:    non_unique: Oei! Niet alle deelnemers hebben een unieke match.entry:    non_unique: Sorry, geen unieke match gevonden voor"%name%"

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/basemail.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/basemail.html.twig
@@ -33,7 +33,7 @@
 				</td>
 				<td width="331" height="21">
                     <span style="font-family: Arial, Helvetica, sans-serif;color:#6e7070;line-height: 21px;background-color:#ffffff;font-size:13px;">{{ 'emails.base.footer'|trans }}
-                        <br/>{{ 'email.base.created_by'|trans }}</span>
+                        <br/>{{ 'emails.base.created_by'|trans }}</span>
 					<a href="http://www.intracto.com" target="_blank" style="color:#b3141c;font-family: Arial, Helvetica, sans-serif; line-height: 21px; background-color: #ffffff;font-size:13px;text-decoration: none">Intracto digital agency</a>
 				</td>
 				<td width="272" headers="36">

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/basemail.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/basemail.html.twig
@@ -1,7 +1,7 @@
  <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-		<title>Secret Santa by Intracto</title>
+        <title>{{ 'emails.base.title'|trans }}</title>
 	</head>
 	<body>
 		<style type="text/css">
@@ -32,7 +32,8 @@
 					<img src="http://www.eproof.be/assets/intracto/secret-santa/left-middle-footer.jpg" width="37" height="21" style="display:block;" border="0" />
 				</td>
 				<td width="331" height="21">
-					<span style="font-family: Arial, Helvetica, sans-serif;color:#6e7070;line-height: 21px;background-color:#ffffff;font-size:13px;">Have fun organizing Secret Santa!<br />Created by</span>
+                    <span style="font-family: Arial, Helvetica, sans-serif;color:#6e7070;line-height: 21px;background-color:#ffffff;font-size:13px;">{{ 'emails.base.footer'|trans }}
+                        <br/>{{ 'email.base.created_by'|trans }}</span>
 					<a href="http://www.intracto.com" target="_blank" style="color:#b3141c;font-family: Arial, Helvetica, sans-serif; line-height: 21px; background-color: #ffffff;font-size:13px;text-decoration: none">Intracto digital agency</a>
 				</td>
 				<td width="272" headers="36">

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/pendingconfirmation.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/pendingconfirmation.html.twig
@@ -7,17 +7,17 @@
 			</td>
 			<td width="566">
 				<span style="font-family: Arial, Helvetica, sans-serif; font-size: 15px; color:#333333; line-height: 25px;">
-					Hi {{ pool.getOwnerName }}, <br /><br/>
-					Please click on the button below to validate your Secret Santa mailing list.  This will trigger our gnomes to send out the personal message you created earlier to all your participants.
+					{{ 'email.pendingconfirmation.salutation'|trans({'%name%': pool.getOwnerName}) }}, <br/><br/>
+                    {{ 'email.pendingconfirmation.click_button'|trans }}
 
 				</span>
 				<br /> <br />
 				<span style="font-family: Arial, Helvetica, sans-serif; font-size: 15px; color:#333333;line-height: 25px;">
-					On the newly created overview page you will then be able to keep track of all your users discovering their Secret Santa gift buddies. Thus knowing when the list is complete.
+					{{ 'emails.pendingconfirmation.overview_page'|trans }}
 				</span>
 				<br /> <br />
                 	<span style="font-family: Arial, Helvetica, sans-serif; font-size: 15px; color:#333333;line-height: 25px;">
-					And lastly, don't forget to confirm your own participation as well! We'll also send you a new e-mail after you click the validation button below.
+					{{ 'emails.pendingconfirmation.lastly'|trans }}
 				</span>
                 <br /> <br />
                 <br />
@@ -53,7 +53,7 @@
 								<tr>
 									<td height="40" valign="middle" style="background-color:#bd1019;">
 										<a href="{{ url('pool_manage', { 'listUrl': pool.listurl }) }}" target="_blank" style="font-family: Arial, Helvetica, sans-serif;background-color:#bd1019;font-size:18px;color:#ffffff;text-decoration: none;display:block;line-height: 40px;height: 40px">
-											Validate my event
+                                            {{ 'emails.pendingconfirmation.btn_validate'|trans }}
 										</a>
 									</td>
 								</tr>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/pendingconfirmation.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/pendingconfirmation.html.twig
@@ -7,8 +7,8 @@
 			</td>
 			<td width="566">
 				<span style="font-family: Arial, Helvetica, sans-serif; font-size: 15px; color:#333333; line-height: 25px;">
-					{{ 'email.pendingconfirmation.salutation'|trans({'%name%': pool.getOwnerName}) }}, <br/><br/>
-                    {{ 'email.pendingconfirmation.click_button'|trans }}
+					{{ 'emails.pendingconfirmation.salutation'|trans({'%name%': pool.getOwnerName}) }}, <br/><br/>
+                    {{ 'emails.pendingconfirmation.click_button'|trans }}
 
 				</span>
 				<br /> <br />

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/pendingconfirmation.txt.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/pendingconfirmation.txt.twig
@@ -1,12 +1,13 @@
-Hi {{ pool.getOwnerName }}
+{{ 'emails.pendingconfirmation.salutation'|trans({'%name%': pool.getOwnerName}) }},
 
-Please click on the link below to validate your Secret Santa mailing list.
-On the newly created overview page you will then be able to keep track of all your users discovering their Secret Santa gift buddies. Thus knowing when the list is complete.
 
-And lastly, don't forget to confirm your own participation as well! We'll also send you a new e-mail after you click the validation button below.
+{{ 'emails.pendingconfirmation.click_link'|trans() }}
+{{ 'emails.pendingconfirmation.overview_page'|trans }}
+
+{{ 'emails.pendingconfirmation.lastly'|trans }}
 
 {{ url('pool_manage', { 'listUrl': pool.listurl }) }}
 
-Have fun organizing Secret Santa!
+{{ 'emails.base.footer'|trans }}
 
-Created by http://www.intracto.com
+{{ 'emails.base.created_by'|trans }} http://www.intracto.com

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/secretsanta.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/secretsanta.html.twig
@@ -42,7 +42,7 @@
 								<tr>
 									<td height="40" valign="middle" style="background-color:#bd1019;">
 										<a href="{{ url('entry_view', { 'url': entry.url }) }}" target="_blank" style="font-family: Arial, Helvetica, sans-serif;background-color:#bd1019;font-size:18px;color:#ffffff;text-decoration: none;display:block;line-height: 40px;height: 40px">
-											Find out your person
+                                            {{ 'emails.secretsanta.btn_find_out'|trans }}
 										</a>
 									</td>
 								</tr>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/secretsanta.txt.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/secretsanta.txt.twig
@@ -1,6 +1,7 @@
 {{ message }}
 
-Find out your randomly assigned person to give a gift to, on this url:
+{{ 'emails.secretsanta.link_find_out'|trans }}:
 {{ url('entry_view', { 'url': entry.url }) }}
 
-Created by http://www.intracto.com
+
+{{ 'emails.base.created_by'|trans }} http://www.intracto.com

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/wishlistchanged.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/wishlistchanged.html.twig
@@ -7,9 +7,9 @@
             </td>
             <td width="566">
 				<span style="font-family: Arial, Helvetica, sans-serif; font-size: 15px; color:#333333; line-height: 25px;">
-					Hi {{ secret_santa.name }}<br /><br />
-                    Your buddy has updated his wishlist.<br/>
-                    Click on the button below to check out his suggestions.
+					{{ 'emails.wishlistchanged.salutation'|trans({'%name%': secret_santa.name}) }},<br/><br/>
+                    {{ 'emails.wishlistchanged.buddy_updated_wishlist'|trans }}<br/>
+                    {{ 'emails.wishlistchanged.click_button'|trans }}
 				</span>
                 <br /> <br /><br />
             </td>
@@ -44,7 +44,7 @@
                                 <tr>
                                     <td height="40" valign="middle" style="background-color:#bd1019;">
                                         <a href="{{ url('entry_view', { 'url': secret_santa.url }) }}" target="_blank" style="font-family: Arial, Helvetica, sans-serif;background-color:#bd1019;font-size:18px;color:#ffffff;text-decoration: none;display:block;line-height: 40px;height: 40px">
-                                            Check wishlist
+                                            {{ 'emails.wishlistchanged.btn_check_wishlist'|trans }}
                                         </a>
                                     </td>
                                 </tr>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/wishlistchanged.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/wishlistchanged.html.twig
@@ -43,7 +43,9 @@
                                 </tr>
                                 <tr>
                                     <td height="40" valign="middle" style="background-color:#bd1019;">
-                                        <a href="{{ url('entry_view', { 'url': secret_santa.url }) }}" target="_blank" style="font-family: Arial, Helvetica, sans-serif;background-color:#bd1019;font-size:18px;color:#ffffff;text-decoration: none;display:block;line-height: 40px;height: 40px">
+                                        <a href="{{ url('entry_view', { 'url': secret_santa.url, '_locale': secret_santa.pool.locale }) }}"
+                                           target="_blank"
+                                           style="font-family: Arial, Helvetica, sans-serif;background-color:#bd1019;font-size:18px;color:#ffffff;text-decoration: none;display:block;line-height: 40px;height: 40px">
                                             {{ 'emails.wishlistchanged.btn_check_wishlist'|trans }}
                                         </a>
                                     </td>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/wishlistchanged.txt.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/wishlistchanged.txt.twig
@@ -1,1 +1,6 @@
-keupt nen beiteren email client!
+{{ 'emails.wishlistchanged.salutation'|trans({'%name%': secret_santa.name}) }},
+
+{{ 'emails.wishlistchanged.buddy_updated_wishlist'|trans }}
+{{ 'emails.wishlistchanged.click_link'|trans }}
+
+{{ url('entry_view', { 'url': secret_santa.url }) }}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/wishlistchanged.txt.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/wishlistchanged.txt.twig
@@ -3,4 +3,4 @@
 {{ 'emails.wishlistchanged.buddy_updated_wishlist'|trans }}
 {{ 'emails.wishlistchanged.click_link'|trans }}
 
-{{ url('entry_view', { 'url': secret_santa.url }) }}
+{{ url('entry_view', { 'url': secret_santa.url, '_locale': secret_santa.pool.locale }) }}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Entry/index.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Entry/index.html.twig
@@ -1,12 +1,13 @@
 {% extends "IntractoSecretSantaBundle::base.html.twig" %}
 {% block header %}
     <div class="steps">
-        <h2>Your <span class="accent">Secret Santa party</span> details</h2>
+        <h2>{{ 'entry.headers.title'|trans|raw }}</h2>
         <ul class="liststyle1">
-            <li><strong>Date </strong> {{ entry.pool.date|date('j F Y') }}</li>
-            <li><strong>Amount </strong> {{ entry.pool.amount }}</li>
-            <li><strong>Number of people </strong> {{ entry.pool.entries|length }}</li>
-            <li><strong>Person who created this list </strong> {{ entry.pool.entries|first.email }}</li>
+            <li><strong>{{ 'entry.headers.date'|trans }} </strong> {{ entry.pool.date|date('j F Y') }}</li>
+            <li><strong>{{ 'entry.headers.amount'|trans }} </strong> {{ entry.pool.amount }}</li>
+            <li><strong>{{ 'entry.headers.num_people'|trans }} </strong> {{ entry.pool.entries|length }}</li>
+            <li><strong>{{ 'entry.headers.person_created_list'|trans }} </strong> {{ entry.pool.entries|first.email }}
+            </li>
         </ul>
     </div>
 {% endblock %}
@@ -14,11 +15,9 @@
     <div class="box">
         <div class="row">
             <div class="span8">
-                <h1>Your assigned buddy</h1>
+                <h1>{{ 'entry.title'|trans }}</h1>
 
-                <p>Hi {{ entry.name }},</p>
-
-                <p>You are assigned as Secret Santa to give a present to:</p>
+                {{ 'entry.body'|trans({'%name%': entry.name})|raw }}
 
                 <div class="yoursecretsant">
                     <span class="yourgift">{{ entry.entry.name }}</span> {{ entry.entry.email }}
@@ -37,13 +36,13 @@
         </div>
 
         <div class="well bottom-spacer">
-            <h4>Wishlist from {{ entry.entry.name }}</h4>
+            <h4>{{ 'entry.wishlist_from'|trans({'%name%': entry.entry.name}) }}</h4>
             {% if(secret_santa.wishlistitems|length == 0) %}
                 {# check for legacy wishlist #}
                 {% if(secret_santa.getwishlist) %}
                     {{ secret_santa.getwishlist|linkify|raw }}
                 {% else %}
-                    {{ entry.entry.name }} has not yet provided a wishlist.
+                    {{ 'entry.wishlist_not_provided'|trans({'%name%': entry.name}) }}.
                 {% endif %}
             {% else %}
                 <ul class="wishlist">
@@ -57,10 +56,8 @@
         <h1>Your wishlist</h1>
 
         <p>
-            <div class="description">To help your Secret Santa, you can leave a wishlist here. Our gnomes will take care of
-                communicating this to your Secret Santa. You can re-order the list by dragging the items in place.
-            </div>
 
+        <div class="description">{{ 'entry.wishlist.description'|trans|raw }}</div>
         <p>
             {{ form_start(form) }}
             {{ form_row(form._token) }}
@@ -76,10 +73,10 @@
                     <thead>
                     <tr>
                         <th class="span1 entry-number-header">#</th>
-                        <th class="span7">Description</th>
+                        <th class="span7">{{ 'label.description'|trans }}</th>
                         <th style="text-align: right;" class="span4">
                             <button type="button" class="btn btn-mini btn-success add-new-entry"><i
-                                        class="icon-plus-sign icon-white"></i> Add item to wishlist
+                                        class="icon-plus-sign icon-white"></i> {{ 'btn.add_wishlist'|trans }}
                             </button>
                         </th>
                     </tr>
@@ -87,7 +84,7 @@
                     <tbody data-prototype="{% filter escape %}{% include 'IntractoSecretSantaBundle:Helpers:prototypeWishlist.html.twig' with {'item': form.wishlistItems.vars['prototype']} %}{% endfilter %}">
                     {% if form.wishlistItems |length == 0 %}
                         <tr class="noitems">
-                            <td colspan="3">Your wishlist is empty. Add something!</td>
+                            <td colspan="3">{{ 'entry.wishlist_empty'|trans }}</td>
                         </tr>
                     {% else %}
                         {% for item in form.wishlistItems %}
@@ -95,7 +92,9 @@
                                 <td {% if form_errors(item.rank) %}class="error"{% endif %}>{{ form_widget(item.rank) }}<span class="rank">{{ item.rank.vars.value }}</span></td>
                                 <td {% if form_errors(item.description) %}class="error"{% endif %}>{{ form_widget(item.description, {'attr': {'class': 'wishlistitem-description'} }) }}</td>
                                 <td style="text-align: right;">
-                                    <button type="button" class="btn btn-mini btn-danger remove-entry"><i class="icon-minus-sign icon-white"></i> Remove this item</button>
+                                    <button type="button" class="btn btn-mini btn-danger remove-entry"><i
+                                                class="icon-minus-sign icon-white"></i> {{ 'btn.remove_item'|trans }}
+                                    </button>
                                 </td>
                             </tr>
                         {% endfor %}
@@ -107,7 +106,7 @@
 
             <p>
                 <br><button type="submit" class="btn btn-large btn-primary">
-                    <i class="icon-ok icon-white"></i> Update your wishlist
+                    <i class="icon-ok icon-white"></i> {{ 'btn.update_wishlist'|trans }}
                 </button>
             </p>
             {{ form_end(form, {'render_rest': false}) }}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Entry/index.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Entry/index.html.twig
@@ -3,7 +3,8 @@
     <div class="steps">
         <h2>{{ 'entry.headers.title'|trans|raw }}</h2>
         <ul class="liststyle1">
-            <li><strong>{{ 'entry.headers.date'|trans }} </strong> {{ entry.pool.date|date('j F Y') }}</li>
+            <li><strong>{{ 'entry.headers.date'|trans }} </strong> {{ entry.pool.date|localizeddate('medium', 'none') }}
+            </li>
             <li><strong>{{ 'entry.headers.amount'|trans }} </strong> {{ entry.pool.amount }}</li>
             <li><strong>{{ 'entry.headers.num_people'|trans }} </strong> {{ entry.pool.entries|length }}</li>
             <li><strong>{{ 'entry.headers.person_created_list'|trans }} </strong> {{ entry.pool.entries|first.email }}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Entry/index.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Entry/index.html.twig
@@ -53,7 +53,7 @@
             {% endif %}
         </div>
 
-        <h1>Your wishlist</h1>
+        <h1>{{ 'entry.wishlist.title'|trans }}</h1>
 
         <p>
 

--- a/src/Intracto/SecretSantaBundle/Resources/views/Helpers/prototypeEntry.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Helpers/prototypeEntry.html.twig
@@ -2,5 +2,8 @@
     <td class="entry-number">__entrycount__</td>
     <td>{{ form_widget(entry.name, {'attr': {'class': 'entry-name'} })  }}</td>
     <td>{{ form_widget(entry.email, {'attr': {'class': 'entry-mail'} })  }}</td>
-    <td style="text-align: right;"><button type="button" class="btn btn-mini btn-danger remove-entry"><i class="icon-minus-sign icon-white"></i> Remove this person</button></td>
+    <td style="text-align: right;">
+        <button type="button" class="btn btn-mini btn-danger remove-entry"><i
+                    class="icon-minus-sign icon-white"></i> {{ 'btn.remove_person'|trans }}</button>
+    </td>
 </tr>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Helpers/prototypeWishlist.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Helpers/prototypeWishlist.html.twig
@@ -2,6 +2,7 @@
     <td {% if form_errors(item.rank) %}class="error"{% endif %}>{{ form_widget(item.rank) }}<span class="rank">{{ item.rank.vars.value }}</span></td>
     <td {% if form_errors(item.description) %}class="error"{% endif %}>{{ form_widget(item.description, {'attr': {'class': 'wishlistitem-description'} }) }}</td>
     <td style="text-align: right;">
-        <button type="button" class="btn btn-mini btn-danger remove-entry"><i class="icon-minus-sign icon-white"></i> Remove this item</button>
+        <button type="button" class="btn btn-mini btn-danger remove-entry"><i
+                    class="icon-minus-sign icon-white"></i> {{ 'btn.remove_item'|trans }}</button>
     </td>
 </tr>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Pool/create.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Pool/create.html.twig
@@ -2,14 +2,14 @@
 
 {% block header %}
     <div class="steps">
-        <h2>Your gift exchange event <br/>in <span class="accent">3 easy steps</span></h2>
+        <h2>{{ 'pool.header.steps.title'|trans|raw }}</h2>
         <ul class="liststyle1">
-            <li><span class="icon-steps">1</span> List your participants</li>
-            <li><span class="icon-steps">2</span> Add a personal message</li>
-            <li><span class="icon-steps">3</span> Send!</li>
+            <li><span class="icon-steps">1</span> {{ 'pool.header.steps.list.one'|trans }}</li>
+            <li><span class="icon-steps">2</span> {{ 'pool.header.steps.list.two'|trans }}</li>
+            <li><span class="icon-steps">3</span> {{ 'pool.header.steps.list.three'|trans }}</li>
         </ul>
         <div class="text-center">
-            <a href="#mysanta" class="btn-started">Get Started!</a>
+            <a href="#mysanta" class="btn-started">{{ 'pool.header.steps.get_started'|trans }}</a>
         </div>
     </div>
 {% endblock %}
@@ -17,20 +17,14 @@
 {% block main %}
 
     <div class="box">
-        <h2>What is Secret Santa?</h2>
+        <h2>{{ 'create.what_is.title'|trans }}</h2>
 
-        <p>It’s a <strong>free</strong> online Secret Santa <strong>gift exchange organizer</strong>! Organize a Secret
-            Santa party with friends, family or even co-workers. After receiving the Secret Santa mail you can add your
-            own <strong>wishlist</strong>, which will be delivered to your Secret Santa.</p>
-
-        <p>Each year around <strong>Christmas</strong> time people all over the world exchange gifts.<br/>
-            To keep things interesting though, you can <strong>randomly assign persons to each other</strong> to give a
-            present to one another.</p>
+        {{ 'create.what_is.intro'|trans|raw }}
     </div>
     <div class="content-container" id="mysanta">
         <div class="santa-content">
 
-            <h1>Add your participants</h1>
+            <h1>{{ 'create.add_participants'|trans }}</h1>
 
             <form action="{{ path('pool_create') }}#mysanta" method="POST" {{ form_enctype(form) }} novalidate>
                 {{ form_row(form._token) }}
@@ -45,11 +39,11 @@
                     <thead>
                     <tr>
                         <th class="span1 entry-number-header">#</th>
-                        <th class="span3">Name</th>
-                        <th class="span4">E-mail</th>
+                        <th class="span3">{{ 'label.name'|trans }}</th>
+                        <th class="span4">{{ 'label.email'|trans }}</th>
                         <th style="text-align: right;" class="span4">
                             <button type="button" class="btn btn-mini btn-success add-new-entry"><i
-                                        class="icon-plus-sign icon-white"></i> Add person
+                                        class="icon-plus-sign icon-white"></i> {{ 'btn.add_person'|trans }}
                             </button>
                         </th>
                     </tr>
@@ -62,10 +56,10 @@
                             <td {% if form_errors(entry.email) %}class="error"{% endif %}>{{ form_widget(entry.email, {'attr': {'class': 'entry-mail'} }) }}</td>
                             <td style="text-align: right;">
                                 {% if loop.index == 1 %}
-                                    <small>This person is also your list administrator.</small>
+                                    <small>{{ 'create.list_adminstrator'|trans }}</small>
                                 {% else %}
                                     <button type="button" class="btn btn-mini btn-danger remove-entry disabled"><i
-                                                class="icon-minus-sign icon-white"></i> Remove this person
+                                                class="icon-minus-sign icon-white"></i> {{ 'btn.remove_person'|trans }}
                                     </button>
                                 {% endif %}
                             </td>
@@ -73,16 +67,16 @@
                     {% endfor %}
                     </tbody>
                 </table>
-                <h1>Add a personal message</h1>
+                <h1>{{ 'create.add_personal_message.title'|trans }}</h1>
 
                 {{ form_widget(form.message, {'attr': {'rows': '8', 'class': 'field span12'} }) }}<br/>
 
                 <div class="description">
-                    Add a personal message for the participants.
+                    {{ 'create.add_personal_message.description'|trans }}
                 </div>
                 <p>
                     <button type="submit" class="btn btn-large btn-primary btn-create-event">
-                        <i class="icon-ok icon-white"></i> Create your event!
+                        <i class="icon-ok icon-white"></i> {{ 'btn.create_event'|trans }}
                     </button>
                 </p>
             </form>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Pool/create.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Pool/create.html.twig
@@ -23,7 +23,6 @@
     </div>
     <div class="content-container" id="mysanta">
         <div class="santa-content">
-
             <h1>{{ 'create.add_participants'|trans }}</h1>
 
             <form action="{{ path('pool_create') }}#mysanta" method="POST" {{ form_enctype(form) }} novalidate>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Pool/create.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Pool/create.html.twig
@@ -28,7 +28,7 @@
             <form action="{{ path('pool_create') }}#mysanta" method="POST" {{ form_enctype(form) }} novalidate>
                 {{ form_row(form._token) }}
                 <div class="row toplabels">
-                    <div class="span3{% if form_errors(form.date) %} error{% endif %}">{{ form_label(form.date) }}{{ form_widget(form.date) }}</div>
+                    <div class="span4{% if form_errors(form.date) %} error{% endif %}">{{ form_label(form.date) }}{{ form_widget(form.date) }}</div>
                     <div class="span3{% if form_errors(form.amount) %} error{% endif %}">{{ form_label(form.amount) }}{{ form_widget(form.amount) }}</div>
                 </div>
 

--- a/src/Intracto/SecretSantaBundle/Resources/views/Pool/created.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Pool/created.html.twig
@@ -1,20 +1,12 @@
 {% extends "IntractoSecretSantaBundle::base.html.twig" %}
 {% block main %}
 <div class="box">
-	<h1>Only 1 step to go! - Validate your participation</h1>
-	<p>
-		To prevent bots or trolls to ruin the Secret Santa party, we need the list organizer <b>{{ pool.ownername }}</b> to validate his or her participation. We've sent a mail to <b>{{ pool.owneremail }}</b> with further instructions.
-	</p>
-	<p>
-		Once validated, your Secret Santa list will be scrambled and all users will receive your message along with the name of their Secret Santa gift buddy.
-	</p>
-	<p>
-		In the validation e-mail the list organizer will also find a link to keep track of all users in their Secret Santa list who've already found out their gift buddy. Making sure every Secret Santa knows his duty.
-	</p>
+    <h1>{{ 'created.title'|trans }}</h1>
+    {{ 'created.body'|trans({ '%ownername%': pool.ownername, '%owneremail%': pool.owneremail })|raw }}
 
     <div class="alert alert-warning">
         <button type="button" class="close" data-dismiss="alert">×</button>
-            <div><strong>Warning!</strong> Don't forget to check your spam folder!</div>
+        <div><strong>{{ 'created.warning'|trans }}</strong> {{ 'created.check_spam'|trans }}</div>
     </div>
 
     {% if app.environment == 'dev' %}<a href="{{ path('pool_manage', { 'listUrl': pool.listUrl }) }}">{{ path('pool_manage', { 'listUrl': pool.listUrl }) }}</a>{% endif %}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Pool/delete.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Pool/delete.html.twig
@@ -1,11 +1,9 @@
 {% extends "IntractoSecretSantaBundle::base.html.twig" %}
 {% block main %}
 <div class="box">
-	<h1>Your Secret Santa list was deleted!</h1>
-	<p>
-	    Thank you for using Secret Santa Organizer. And, we hope to see you again next year!
-	</p>
+    <h1>{{ 'delete.title'|trans }}</h1>
+    {{ 'deleted.body'|trans|raw }}
     <div>
-        <a class="btn btn-primary" href="{{ path('pool_create') }}#mysanta">Create a new Secret Santa list</a>
+        <a class="btn btn-primary" href="{{ path('pool_create') }}#mysanta">{{ 'btn.create_new_list'|trans }}</a>
     </div>
 {% endblock %}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Pool/exclude.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Pool/exclude.html.twig
@@ -14,7 +14,7 @@
 
 {% block main %}
     <div class="box">
-        <h1>Exclude</h1>
+        <h1>{{ 'exclude.title'|trans }}</h1>
 
         {{ form_start(form) }}
         {# Only show general validation error if there are no subform errors #}
@@ -25,8 +25,8 @@
             <thead>
             <tr>
                 <th class="span1">#</th>
-                <th class="span3">Name</th>
-                <th>Exclude</th>
+                <th class="span3">{{ 'label.name'|trans }}</th>
+                <th>{{ 'label.exclude'|trans }}</th>
             </tr>
             </thead>
             <tbody>
@@ -35,7 +35,7 @@
                     <td class="entry-number">{{ loop.index }}</td>
                     <td>{{ entry.excluded_entries.vars.label }}</td>
                     <td>
-                        {{ form_widget(entry.excluded_entries, {'attr': {'placeholder': 'Click and choose the participants you want to exclude'} } ) }}
+                        {{ form_widget(entry.excluded_entries, {'attr': {'placeholder': 'placeholder.exclude'|trans} } ) }}
                         {{ form_errors(entry.excluded_entries) }}
                     </td>
                 </tr>
@@ -44,7 +44,7 @@
         </table>
         <p>
             <button type="submit" class="btn btn-large btn-primary btn-create-event">
-                <i class="icon-ok icon-white"></i> Create your event!
+                <i class="icon-ok icon-white"></i> {{ 'btn.create_event'|trans }}
             </button>
         </p>
         {{ form_end(form) }}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Pool/manage.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Pool/manage.html.twig
@@ -53,8 +53,8 @@
         <div id="delete_pool" class="alert alert-error" style="display: none;">
             <h3>{{ 'delete.title'|trans }}</h3>
 
-            {% set phraseToType = 'delete.pharse_to_type'|trans %}
-            {{ 'delete.body'|trans({ '%pharse_to_type%': phraseToType})|raw }}
+            {% set phraseToType = 'delete.phrase_to_type'|trans %}
+            {{ 'delete.body'|trans({ '%phrase_to_type%': phraseToType})|raw }}
 
             <form action="{{ path('pool_delete', { 'listUrl': pool.listUrl }) }}" method="post">
                 <input type="hidden" name="csrf_token" value="{{ delete_pool_csrf_token }}">

--- a/src/Intracto/SecretSantaBundle/Resources/views/Pool/manage.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Pool/manage.html.twig
@@ -1,68 +1,67 @@
 {% extends "IntractoSecretSantaBundle::base.html.twig" %}
 {% block main %}
     <div class="box">
-        <h1>Your Secret Santa list</h1>
+        <h1>{{ 'manage.title'|trans }}</h1>
         <table class="entries table table-striped" id="mysanta">
             <thead>
-                <tr>
-                    <th class="span1 entry-number-header">#</th>
-                    <th class="span3">Name</th>
-                    <th class="span4">E-mail</th>
-                    <th class="span4">Confirmed</th>
-                    <th class="span1">Actions</th>
-                </tr>
+            <tr>
+                <th class="span1 entry-number-header">#</th>
+                <th class="span3">{{ 'label.name'|trans }}</th>
+                <th class="span4">{{ 'label.email'|trans }}</th>
+                <th class="span4">{{ 'label.confirmed'|trans }}</th>
+                <th class="span1">{{ 'label.actions'|trans }}</th>
+            </tr>
             </thead>
             <tbody>
-                {% for entry in pool.entries %}
+            {% for entry in pool.entries %}
                 <tr class="entry {% if loop.index == 1 %}owner{% else %}not-owner{% endif %}">
                     <td class="entry-number">{{ loop.index }}</td>
                     <td>{{ entry.name }}</td>
                     <td id="email_{{ entry.id }}">{{ entry.email }}</td>
-                    <td class="{% if entry.viewdate %}viewed">Yes{% else %}not_viewed">Not yet{% endif %}</td>
+                    <td class="{% if entry.viewdate %}viewed">{{ 'manage.yes'|trans }}{% else %}not_viewed">{{ 'manage.not_yet'|trans }}{% endif %}</td>
                     <td style="text-align: right;">
                         <img src="{{ asset('bundles/intractosecretsanta/img/edit.png') }}"
                              onclick="editableEmail('{{ pool.listUrl }}', {{ entry.id }});"
-                             rel="tooltip" title="Edit e-mail" alt="Edit e-mail" style="cursor: pointer;">
+                             rel="tooltip" title="{{ 'manage.edit_email'|trans }}" alt="{{ 'manage.edit_email'|trans }}"
+                             style="cursor: pointer;">
                         {% spaceless %}
                             <a href="{{ path('pool_resend', { 'listUrl': pool.listUrl, 'entryId': entry.id }) }}">
-                                <img src="{{ asset('bundles/intractosecretsanta/img/envelope.png') }}" rel="tooltip" title="Resend e-mail" alt="Resend e-mail">
+                                <img src="{{ asset('bundles/intractosecretsanta/img/envelope.png') }}" rel="tooltip"
+                                     title="{{ 'manage.resend_email'|trans }}" alt="{{ 'manage.resend_email'|trans }}">
                             </a>
                         {% endspaceless %}
                         {% if app.environment == 'dev' %}
                             <a href="{{ path('entry_view', { 'url': entry.url }) }}">
                                 <img src="{{ asset('bundles/intractosecretsanta/img/view.png') }}" rel="tooltip"
-                                     title="{{ entry.entry.name }} <{{ entry.entry.email }}>" alt="View entry">
+                                     title="{{ entry.entry.name }} <{{ entry.entry.email }}>"
+                                     alt="{{ 'manage.view_entry'|trans }}">
                             </a>
                         {% endif %}
                     </td>
                 </tr>
-                {% endfor %}
+            {% endfor %}
             </tbody>
         </table>
 
         <div class="alert alert-info">
-            <strong>Tip</strong>  You can always come back to this page to make sure everybody has checked his or her mailbox.
+            <strong>{{ 'manage.tip'|trans }}</strong> {{ 'manage.come_back'|trans }}
         </div>
 
-        <button onclick="$('#delete_pool').show(); $(this).hide(); $('#confirmation').focus();" class="btn btn-primary"><i class="icon-warning-sign icon-white"></i> Delete my Secret Santa list</button>
+        <button onclick="$('#delete_pool').show(); $(this).hide(); $('#confirmation').focus();" class="btn btn-primary">
+            <i class="icon-warning-sign icon-white"></i> {{ 'btn.delete_list'|trans }}
+        </button>
         <div id="delete_pool" class="alert alert-error" style="display: none;">
-            <h3>Delete my Secret Santa list</h3>
-            <p>
-                Are you ABSOLUTELY sure?<br>
-                <br>
-                <b>Unexpected bad things will happen if you don't read this!</b><br>
-                <br>
-                Once you delete your Secret Santa list, there is no going back. This action CANNOT be undone.<br>
-                This will delete this Secret Santa list, all it's participants and their wishlists permanently.<br>
-                <br>
-                Please type "<b>delete everything</b>" below to confirm.<br>
-            </p>
+            <h3>{{ 'delete.title'|trans }}</h3>
+
+            {% set phraseToType = 'delete.pharse_to_type'|trans %}
+            {{ 'delete.body'|trans({ '%pharse_to_type%': phraseToType})|raw }}
+
             <form action="{{ path('pool_delete', { 'listUrl': pool.listUrl }) }}" method="post">
                 <input type="hidden" name="csrf_token" value="{{ delete_pool_csrf_token }}">
                 <input type="text" name="confirmation" id="confirmation" autocomplete="off"
-                       onkeyup="if ($(this).val() == 'delete everything') $('#btn_confirmation').removeAttr('disabled');"><br>
+                       onkeyup="if ($(this).val() == '{{ phraseToType }}') $('#btn_confirmation').removeAttr('disabled');"><br>
                 <button class="btn btn-primary" type="submit" id="btn_confirmation" disabled>
-                    I understand the consequences, delete my Secret Santa list now
+                    {{ 'btn.delete_confirm'|trans }}
                 </button>
             </form>
         </div>
@@ -78,10 +77,10 @@
             url = url.replace("listUrl", listUrl);
             url = url.replace("entryId", entryId);
             $('#email_' + entryId).html(
-                '<form action="' + url + '" method="post">' +
+                    '<form action="' + url + '" method="post">' +
                     '<input type="text" name="email" value="' + email + '">&nbsp;' +
-                    '<button class="btn btn-small btn-primary" type="submit"><i class="icon-ok icon-white"></i> Save</button>' +
-                '</form>'
+                    '<button class="btn btn-small btn-primary" type="submit"><i class="icon-ok icon-white"></i> {{ 'manage.save'|trans }}</button>' +
+                    '</form>'
             );
         }
     </script>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Static/privacypolicy.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Static/privacypolicy.html.twig
@@ -1,23 +1,10 @@
-
 {% extends "IntractoSecretSantaBundle::base.html.twig" %}
 {% block main %}
-  <div class="box">
-    <h1>Privacy Policy</h1>
-    <p>Thank you for visiting secretsantaorganizer.com created by Intracto group NV. This privacy policy tells you how we use personal information collected at this site. Please read this privacy policy before using the site or submitting any personal information. By using the site, you are accepting the practices described in this privacy policy. These practices may be changed, but any changes will be posted and changes will only apply to activities and information on a going forward, not retroactive basis. You are encouraged to review the privacy policy whenever you visit the site to make sure that you understand how any personal information you provide will be used.</p>
-    <p>Note: the privacy practices set forth in this privacy policy are for this web site only. If you link to other web sites, please review the privacy policies posted at those sites.</p>
-    <h2>Collection of Information</h2>
-    <p>We collect personally identifiable information, like names and email addresses, when voluntarily submitted by our visitors. The information you provide is used to fulfill your specific request.</p>
-    <h2>Cookie/Tracking Technology</h2>
-    <p>This site uses cookies present in Google Analytics for gathering anonymous information such as browser type and operating system, tracking the number of visitors to the site, and understanding how visitors use the site. Personal information cannot be collected via cookies and other tracking technology.</p>
-    <p>You can turn off the use of cookies in the settings of your browser.</p>
-    <h2>Distribution of Information</h2>
-    <p>We may share information with governmental agencies or other companies assisting us in fraud prevention or investigation. We may do so when: (1) permitted or required by law; or, (2) trying to protect against or prevent actual or potential fraud or unauthorized transactions; or, (3) investigating fraud which has already taken place. The information is not provided to these companies for marketing purposes.</p>
-    <h2>Commitment to Data Security</h2>
-    <p>Your personally identifiable information is kept secure. Only authorized employees, agents and contractors (who have agreed to keep information secure and confidential) have access to this information. All emails from this site are unique to your specific request. No recurring emails or newsletters will be sent to the email addresses provided.</p>
-    <h2>Privacy Contact Information</h2>
-    <p>If you have any questions, concerns, or comments about our privacy policy you may contact us using the information below:<br />
-    By e-mail: info@secretsantaorganizer.com</p>
-    <p>We reserve the right to make changes to this policy. Any changes to this policy will be posted.</p>
-    <p><a href="{{ url('pool_create') }}" class="btn btn-large btn-primary">Start creating your list</a></p>
-  </div>
+    <div class="box">
+        <h1>{{ 'static.privacy_policy'|trans }}</h1>
+        {{ 'static.privacy_policy.body'|trans }}
+
+        <p><a href="{{ url('pool_create') }}" class="btn btn-large btn-primary">{{ 'btn.create_new_list'|trans }}</a>
+        </p>
+    </div>
 {% endblock %}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Static/privacypolicy.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Static/privacypolicy.html.twig
@@ -1,8 +1,8 @@
 {% extends "IntractoSecretSantaBundle::base.html.twig" %}
 {% block main %}
     <div class="box">
-        <h1>{{ 'static.privacy_policy'|trans }}</h1>
-        {{ 'static.privacy_policy.body'|trans }}
+        <h1>{{ 'static.privacy_policy.title'|trans }}</h1>
+        {{ 'static.privacy_policy.body'|trans|raw }}
 
         <p><a href="{{ url('pool_create') }}" class="btn btn-large btn-primary">{{ 'btn.create_new_list'|trans }}</a>
         </p>

--- a/src/Intracto/SecretSantaBundle/Resources/views/base.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/base.html.twig
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
     <meta name="description" content="{{ 'base.meta.description'|trans }}"/>
-    <meta property="og:title" content="Secret Santa"/>
+    <meta property="og:title" content="{{ 'base.meta.og.title'|trans }}"/>
     <meta property="og:image" content="http://secretsantaorganiser.com/bundles/intractosecretsanta/img/ico/social.jpg"/>
     <meta property="og:site_name" content="{{ 'base.meta.og.site_name'|trans }}"/>
     <meta property="og:description" content="{{ 'base.meta.og.description'|trans }}"/>

--- a/src/Intracto/SecretSantaBundle/Resources/views/base.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/base.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ app.request.get('_locale') }}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
@@ -65,6 +65,15 @@
 
 <div class="wrapper">
     <div class="container">
+        <ul id="locale-menu">
+            {% for supported_locale in supported_locales if supported_locale != app.request.get('_locale') %}
+                <li>
+                    <a href="{{ url(app.request.get('_route'), app.request.get('_route_params')|merge({'_locale': supported_locale, 'force-locale-switch': true})) }}">
+                        {{ supported_locale }}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
         <div id="header">
             <a id="homelink" href="{{ url('pool_create') }}">{{ 'nav.home'|trans }}</a>
             {% block header %}{% endblock %}

--- a/src/Intracto/SecretSantaBundle/Resources/views/base.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/base.html.twig
@@ -9,6 +9,11 @@
     <meta property="og:site_name" content="{{ 'base.meta.og.site_name'|trans }}"/>
     <meta property="og:description" content="{{ 'base.meta.og.description'|trans }}"/>
     <title>{% block title %}{{ 'base.meta.title'|trans }}{% endblock %}</title>
+
+    {% for supported_locale in supported_locales if supported_locale != app.request.get('_locale') %}
+        <link rel="alternate" hreflang="{{ supported_locale }}"
+              href="{{ url(app.request.get('_route'), app.request.get('_route_params')|merge({'_locale': supported_locale})) }}"/>
+    {% endfor %}
     {#<link href="{{ asset('/bundles/intractosecretsanta/css/bootstrap.min.css') }}" rel="stylesheet" media="screen">#}
     {#<link href="{{ asset('/bundles/intractosecretsanta/css/update.css') }}" rel="stylesheet" media="screen">#}
     {#<link href="{{ asset('/bundles/intractosecretsanta/css/mediaqueries.css') }}" rel="stylesheet" media="screen">#}

--- a/src/Intracto/SecretSantaBundle/Resources/views/base.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/base.html.twig
@@ -2,89 +2,98 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <meta name="description" content="Secret Santa Organizer is a free online Secret Santa gift exchange organizer! Organize a Secret Santa party with friends, family or even co-workers and add your wishlist."/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+    <meta name="description" content="{{ 'base.meta.description'|trans }}"/>
     <meta property="og:title" content="Secret Santa"/>
     <meta property="og:image" content="http://secretsantaorganiser.com/bundles/intractosecretsanta/img/ico/social.jpg"/>
-    <meta property="og:site_name" content="Secret Santa"/>
-    <meta property="og:description" content="Secret Santa Organizer is a free online Secret Santa gift exchange organizer! Organize a Secret Santa party with friends, family or even co-workers and add your wishlist."/>
-    <title>{% block title %}Secret Santa Online gift exchange organizer!{% endblock %}</title>
+    <meta property="og:site_name" content="{{ 'base.meta.og.site_name'|trans }}"/>
+    <meta property="og:description" content="{{ 'base.meta.og.description'|trans }}"/>
+    <title>{% block title %}{{ 'base.meta.title'|trans }}{% endblock %}</title>
     {#<link href="{{ asset('/bundles/intractosecretsanta/css/bootstrap.min.css') }}" rel="stylesheet" media="screen">#}
     {#<link href="{{ asset('/bundles/intractosecretsanta/css/update.css') }}" rel="stylesheet" media="screen">#}
     {#<link href="{{ asset('/bundles/intractosecretsanta/css/mediaqueries.css') }}" rel="stylesheet" media="screen">#}
     {% block stylesheets %}{% endblock %}
-         {% stylesheets
-         'bundles/intractosecretsanta/css/bootstrap.min.css'
-         'bundles/intractosecretsanta/css/update.css'
-         'bundles/intractosecretsanta/css/mediaqueries.css'
-         'bundles/intractosecretsanta/css/jquery-ui.css'
-         filter='cssrewrite' %}
-    <link href="{{ asset_url }}" rel="stylesheet" media="screen" />
+    {% stylesheets
+    'bundles/intractosecretsanta/css/bootstrap.min.css'
+    'bundles/intractosecretsanta/css/update.css'
+    'bundles/intractosecretsanta/css/mediaqueries.css'
+    'bundles/intractosecretsanta/css/jquery-ui.css'
+    filter='cssrewrite' %}
+    <link href="{{ asset_url }}" rel="stylesheet" media="screen"/>
     {% endstylesheets %}
     <style>
-    table.entries input {
-        margin-bottom: 0;
-    }
+        table.entries input {
+            margin-bottom: 0;
+        }
     </style>
     <link rel="shortcut icon" href="{{ asset('/bundles/intractosecretsanta/img/ico/favicon.ico') }}">
-    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ asset('/bundles/intractosecretsanta/img/ico/apple-touch-icon-144-precomposed.png') }}">
-    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ asset('/bundles/intractosecretsanta/img/ico/apple-touch-icon-114-precomposed.png') }}">
-    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ asset('/bundles/intractosecretsanta/img/ico/apple-touch-icon-72-precomposed.png') }}">
-    <link rel="apple-touch-icon-precomposed" href="{{ asset('/bundles/intractosecretsanta/img/ico/apple-touch-icon-57-precomposed.png') }}">
+    <link rel="apple-touch-icon-precomposed" sizes="144x144"
+          href="{{ asset('/bundles/intractosecretsanta/img/ico/apple-touch-icon-144-precomposed.png') }}">
+    <link rel="apple-touch-icon-precomposed" sizes="114x114"
+          href="{{ asset('/bundles/intractosecretsanta/img/ico/apple-touch-icon-114-precomposed.png') }}">
+    <link rel="apple-touch-icon-precomposed" sizes="72x72"
+          href="{{ asset('/bundles/intractosecretsanta/img/ico/apple-touch-icon-72-precomposed.png') }}">
+    <link rel="apple-touch-icon-precomposed"
+          href="{{ asset('/bundles/intractosecretsanta/img/ico/apple-touch-icon-57-precomposed.png') }}">
     {% if app.environment == 'prod' %}
         <script type="text/javascript">
             var _gaq = _gaq || [];
             _gaq.push(['_setAccount', '{{ ga_tracking }}']);
             _gaq.push(['_trackPageview']);
 
-            (function() {
-                var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+            (function () {
+                var ga = document.createElement('script');
+                ga.type = 'text/javascript';
+                ga.async = true;
                 ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-                var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+                var s = document.getElementsByTagName('script')[0];
+                s.parentNode.insertBefore(ga, s);
             })();
         </script>
     {% endif %}
 </head>
 <body>
-    <a class="github" href="https://github.com/Intracto/SecretSanta" target="_blank">
-        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub">
-    </a>
-    <div class="wrapper">
-        <div class="container">
-            <div id="header">
-                <a id="homelink" href="{{ url('pool_create') }}">Home</a>
-                {% block header %}{% endblock %}
-            </div>
-            {% for flashMessageType in app.session.flashbag.keys %}
-                {% if app.session.flashbag.has(flashMessageType) %}
-                    <div class="alert alert-{{ flashMessageType }}">
-                        <button type="button" class="close" data-dismiss="alert">×</button>
-                        {% for flashMessage in app.session.flashbag.get(flashMessageType) %}
-                            <div>{{ flashMessage|raw }}</div>
-                        {% endfor %}
-                    </div>
-                {% endif %}
-            {% endfor %}
-            {% block main %}{% endblock %}
-            {% block footer %}
-                <div id="footer-santa" class="clearfix">
-                    <div class="copyright">&copy;{{ "now"|date("Y") }} <a href="http://www.intracto.com" target="_blank">Intracto digital agency</a></div>
-                    <div class="footer-links">
-                        <a href="{{ url('privacypolicy') }}">Privacy policy</a>
-                    </div>
-                    Have fun organizing your Secret Santa!
-                </div>
-            {% endblock %}
+<a class="github" href="https://github.com/Intracto/SecretSanta" target="_blank">
+    <img style="position: absolute; top: 0; right: 0; border: 0;"
+         src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub">
+</a>
+
+<div class="wrapper">
+    <div class="container">
+        <div id="header">
+            <a id="homelink" href="{{ url('pool_create') }}">{{ 'nav.home'|trans }}</a>
+            {% block header %}{% endblock %}
         </div>
+        {% for flashMessageType in app.session.flashbag.keys %}
+            {% if app.session.flashbag.has(flashMessageType) %}
+                <div class="alert alert-{{ flashMessageType }}">
+                    <button type="button" class="close" data-dismiss="alert">×</button>
+                    {% for flashMessage in app.session.flashbag.get(flashMessageType) %}
+                        <div>{{ flashMessage|raw }}</div>
+                    {% endfor %}
+                </div>
+            {% endif %}
+        {% endfor %}
+        {% block main %}{% endblock %}
+        {% block footer %}
+            <div id="footer-santa" class="clearfix">
+                <div class="copyright">&copy;{{ "now"|date("Y") }} <a href="http://www.intracto.com" target="_blank">Intracto
+                        digital agency</a></div>
+                <div class="footer-links">
+                    <a href="{{ url('privacypolicy') }}">{{ 'base.privacy_policy'|trans }}</a>
+                </div>
+                {{ 'base.have_fun'|trans }}
+            </div>
+        {% endblock %}
     </div>
-    {% javascripts
-    '@IntractoSecretSantaBundle/Resources/public/js/jquery-1.8.2.min.js'
-    '@IntractoSecretSantaBundle/Resources/public/js/jquery-ui-1.9.0.js'
-    '@IntractoSecretSantaBundle/Resources/public/js/bootstrap.min.js'
-    '@IntractoSecretSantaBundle/Resources/public/js/secretsanta.js'
-    %}
-    <script type="text/javascript" src="{{ asset_url }}"></script>
-    {% endjavascripts %}
-    {% block javascripts %}{% endblock %}
+</div>
+{% javascripts
+'@IntractoSecretSantaBundle/Resources/public/js/jquery-1.8.2.min.js'
+'@IntractoSecretSantaBundle/Resources/public/js/jquery-ui-1.9.0.js'
+'@IntractoSecretSantaBundle/Resources/public/js/bootstrap.min.js'
+'@IntractoSecretSantaBundle/Resources/public/js/secretsanta.js' %}
+<script type="text/javascript" src="{{ asset_url }}"></script>
+{% endjavascripts %}
+{% block javascripts %}{% endblock %}
 </body>
 </html>

--- a/src/Intracto/SecretSantaBundle/Validator/EntryHasValidExcludes.php
+++ b/src/Intracto/SecretSantaBundle/Validator/EntryHasValidExcludes.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Constraint;
  */
 class EntryHasValidExcludes extends Constraint
 {
-    public $messageNoUniqueMatch = 'entry.non_unique"';
+    public $messageNoUniqueMatch = 'entry.non_unique';
 
     public function validatedBy()
     {

--- a/src/Intracto/SecretSantaBundle/Validator/EntryHasValidExcludes.php
+++ b/src/Intracto/SecretSantaBundle/Validator/EntryHasValidExcludes.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Constraint;
  */
 class EntryHasValidExcludes extends Constraint
 {
-    public $messageNoUniqueMatch = 'No unique match found for "%name%"';
+    public $messageNoUniqueMatch = 'entry.non_unique"';
 
     public function validatedBy()
     {

--- a/src/Intracto/SecretSantaBundle/Validator/PoolHasValidExcludes.php
+++ b/src/Intracto/SecretSantaBundle/Validator/PoolHasValidExcludes.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Constraint;
  */
 class PoolHasValidExcludes extends Constraint
 {
-    public $message = 'Not all entries have an unique match.';
+    public $message = 'pool.non_unique';
 
     public function validatedBy()
     {


### PR DESCRIPTION
Hi,

Added multilingual support. 
Available locales are requested through the parameters.yml.
Auto creates routes for all the available locales using the locale in the route (/nl/privacy-policy, /fr/privacy-policy, etc) except for the default locale (en) which stays the same
