### PR TITLE
#64 Wishlist doesn't work in Firefox

### DIFF
--- a/src/Intracto/SecretSantaBundle/Resources/public/js/wishlist.js
+++ b/src/Intracto/SecretSantaBundle/Resources/public/js/wishlist.js
@@ -68,6 +68,6 @@ jQuery(document).ready(function() {
         stop: function () {
             resetRanks();
         }
-    }).disableSelection();
+    });
 
 });


### PR DESCRIPTION
Removed .disableSelection() call as this is no longer advised and breaks Firefox as it doesn't allow selection of input type=text elements inside the sortable container

Tested working in Chrome 43, Firefox 38 and IE 11, all on Windows 8
Still needs testing on other OS'es / versions