### PR TITLE
Re-enable and improve excludes

### DIFF
--- a/src/Intracto/SecretSantaBundle/Controller/PoolController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/PoolController.php
@@ -82,22 +82,6 @@ class PoolController extends Controller
                 $em->persist($pool);
                 $em->flush();
 
-                //------- Remove between these lines if a fix has been find for max_execution_time error when shuffling
-
-
-                $pool->setCreated(true);
-                $em->persist($pool);
-                $em->flush();
-
-                $this->eventDispatcher->dispatch(
-                    PoolEvents::NEW_POOL_CREATED,
-                    new PoolEvent($pool)
-                );
-
-                return $this->redirect($this->generateUrl('pool_created', array('listUrl' => $pool->getListurl())));
-
-                //-------
-
                 return $this->redirect($this->generateUrl('pool_exclude', array('listUrl' => $pool->getListurl())));
             }
         }
@@ -127,6 +111,12 @@ class PoolController extends Controller
 
                 $this->pool->setCreated(true);
                 $em->persist($this->pool);
+
+                /** @var \Intracto\SecretSantaBundle\Entity\EntryService $entryService */
+                $entryService = $this->get('intracto_secret_santa.entry_service');
+
+                $entryService->shuffleEntries($this->pool);
+
                 $em->flush();
 
                 $this->eventDispatcher->dispatch(
@@ -178,7 +168,6 @@ class PoolController extends Controller
             /** @var \Intracto\SecretSantaBundle\Entity\EntryService $entryService */
             $entryService = $this->get('intracto_secret_santa.entry_service');
 
-            $entryService->shuffleEntries($this->pool);
             $entryService->sendSecretSantaMailsForPool($this->pool);
         }
 

--- a/src/Intracto/SecretSantaBundle/Entity/EntryService.php
+++ b/src/Intracto/SecretSantaBundle/Entity/EntryService.php
@@ -61,24 +61,7 @@ class EntryService
      */
     public function shuffleEntries(Pool $pool)
     {
-        //-----------------------
-        $entries = $pool->getEntries()->getValues();
-        shuffle($entries);
-        foreach ($entries as $index => $entry) {
-            if ($index === count($entries) - 1) {
-                $peer = $entries[0];
-            } else {
-                $peer = $entries[$index + 1];
-            }
-            $entry
-                ->setEntry($peer)
-                ->setUrl(base_convert(sha1(uniqid(mt_rand(), true)), 16, 36));
-            $this->em->persist($entry);
-        }
-        $this->em->flush();
-
-        //-----------------------
-        /*
+        //Validator should already have shuffled it.
         if (!$shuffled = $this->entryShuffler->shuffleEntries($pool)) {
             return false;
         }
@@ -91,7 +74,7 @@ class EntryService
             $this->em->persist($entry);
         }
 
-        $this->em->flush();*/
+        $this->em->flush();
     }
 
     /**

--- a/src/Intracto/SecretSantaBundle/Entity/EntryShuffler.php
+++ b/src/Intracto/SecretSantaBundle/Entity/EntryShuffler.php
@@ -7,6 +7,10 @@ namespace Intracto\SecretSantaBundle\Entity;
  */
 class EntryShuffler
 {
+    const SHUFFLE_TIME_LIMIT = 10; //sec
+
+    private $matchedExcludes;
+
     /**
      * @param Pool $pool
      *
@@ -14,7 +18,11 @@ class EntryShuffler
      */
     public function shuffleEntries(Pool $pool)
     {
-        return $this->permutateTillMatch($pool);
+        if ($this->matchedExcludes) {
+            return $this->matchedExcludes;
+        }
+
+        return $this->shuffleTillMatch($pool);
     }
 
     /**
@@ -22,16 +30,20 @@ class EntryShuffler
      *
      * @return array|bool
      */
-    private function permutateTillMatch(Pool $pool)
+    private function shuffleTillMatch(Pool $pool)
     {
+        $timeToStop = microtime(true) + self::SHUFFLE_TIME_LIMIT;
         $entries = $pool->getEntries()->getValues();
-        $set = $this->shuffleArray($entries);
-        do {
+
+        while (microtime(true) < $timeToStop) {
+            $set = $this->shuffleArray($entries);
             if ($this->checkValidMatch($entries, $set)) {
+                $this->matchedExcludes = $set;
                 return $set;
             }
-        } while ($set = $this->shuffleArray($entries));
+        };
 
+        return false;
     }
 
     /**

--- a/src/Intracto/SecretSantaBundle/Resources/translations/validators.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/validators.en.yml
@@ -1,4 +1,4 @@
 pool:
-    non_unique: Not all entries have an unique match.
+    non_unique: Not all entries have an unique match. Try again or remove some combination from the exclude list.
 entry:
     non_unique: No unique match found for "%name%"

--- a/src/Intracto/SecretSantaBundle/Resources/translations/validators.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/validators.nl.yml
@@ -1,1 +1,1 @@
-pool:    non_unique: Oei! Niet alle deelnemers hebben een unieke match.entry:    non_unique: Sorry, geen unieke match gevonden voor"%name%"
+pool:    non_unique: Oei! Niet alle deelnemers hebben een unieke match. Probeer het opnieuw of verwijder enkele combinaties uit de uitsluitingentry:    non_unique: Sorry, geen unieke match gevonden voor"%name%"

--- a/src/Intracto/SecretSantaBundle/Tests/EntryShufflerTest.php
+++ b/src/Intracto/SecretSantaBundle/Tests/EntryShufflerTest.php
@@ -1724,4 +1724,32 @@ class EntryShufflerTest extends \PHPUnit_Framework_TestCase
             }
         }
     }
+
+    public function testEntryShufflerCase4()
+    {
+        $pool = new Pool();
+        foreach ($pool->getEntries() as $defaultEntry) {
+            $pool->removeEntry($defaultEntry);
+        }
+
+        $entry1 = new Entry();
+        $entry1->setName('Entry 1');
+        $pool->addEntrie($entry1);
+
+        $entry2 = new Entry();
+        $entry2->setName('Entry 2');
+        $pool->addEntrie($entry2);
+
+        $entry3 = new Entry();
+        $entry3->setName('Entry 3');
+        $pool->addEntrie($entry3);
+
+        $entry1->addExcludedEntry($entry2);
+        $entry1->addExcludedEntry($entry3);
+
+        $entryShuffler = new EntryShuffler();
+        $shuffeledEntries = $entryShuffler->shuffleEntries($pool);
+        $this->assertFalse($shuffeledEntries);
+
+    }
 }


### PR DESCRIPTION
Based on @TomCan  code.
Improved it with a time limit of 10 sec.
Then an error wil be shown to the user to try again or remove some combinations.

The valdiator already shuffles the entries, checking for a valid match. 
The EntryShuffler service then re-uses that shuffled list and saves it.