### PR TITLE
Reuse previous list

### DIFF
--- a/src/Intracto/SecretSantaBundle/Controller/PoolController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/PoolController.php
@@ -58,37 +58,19 @@ class PoolController extends Controller
     {
         $pool = new Pool();
 
-        $form = $this->createForm(new PoolType(), $pool);
+        return $this->handlePoolCreation($request, $pool);
+    }
 
-        if ('POST' === $request->getMethod()) {
-            $form->handleRequest($request);
-            if ($form->isValid()) {
-                foreach ($pool->getEntries() as $entry) {
-                    $entry->setPool($pool);
-                }
-                $em = $this->getDoctrine()->getManager();
+    /**
+     * @Route("/reuse/{listUrl}", name="pool_reuse")
+     * @Template("IntractoSecretSantaBundle:Pool:create.html.twig")
+     */
+    public function reuseAction(Request $request, $listUrl)
+    {
+        $this->getPool($listUrl);
+        $pool = $this->pool->createNewForReuse();
 
-                $dateFormatter = \IntlDateFormatter::create($request->getLocale(), \IntlDateFormatter::MEDIUM, \IntlDateFormatter::NONE);
-
-                $translator = $this->get('translator');
-                $message = $translator->trans('emails.created.message', array(
-                    '%amount%' => $pool->getAmount(),
-                    '%date%' => $dateFormatter->format($pool->getDate()->getTimestamp()),
-                    '%message%' => $pool->getMessage(),
-                ));
-
-                $pool->setMessage($message);
-                $pool->setLocale($request->getLocale());
-                $em->persist($pool);
-                $em->flush();
-
-                return $this->redirect($this->generateUrl('pool_exclude', array('listUrl' => $pool->getListurl())));
-            }
-        }
-
-        return array(
-            'form' => $form->createView(),
-        );
+        return $this->handlePoolCreation($request, $pool);
     }
 
     /**
@@ -330,5 +312,43 @@ class PoolController extends Controller
         }
 
         return true;
+    }
+
+    private function handlePoolCreation(Request $request, Pool $pool)
+    {
+        $form = $this->createForm(new PoolType(), $pool);
+
+        if ('POST' === $request->getMethod()) {
+            $form->handleRequest($request);
+            if ($form->isValid()) {
+                foreach ($pool->getEntries() as $i => $entry) {
+                    if ($i == 0) {
+                        $entry->setPoolAdmin(true);
+                    }
+                    $entry->setPool($pool);
+                }
+                $em = $this->getDoctrine()->getManager();
+
+                $dateFormatter = \IntlDateFormatter::create($request->getLocale(), \IntlDateFormatter::MEDIUM, \IntlDateFormatter::NONE);
+
+                $translator = $this->get('translator');
+                $message = $translator->trans('emails.created.message', array(
+                    '%amount%' => $pool->getAmount(),
+                    '%date%' => $dateFormatter->format($pool->getDate()->getTimestamp()),
+                    '%message%' => $pool->getMessage(),
+                ));
+
+                $pool->setMessage($message);
+                $pool->setLocale($request->getLocale());
+                $em->persist($pool);
+                $em->flush();
+
+                return $this->redirect($this->generateUrl('pool_exclude', array('listUrl' => $pool->getListurl())));
+            }
+        }
+
+        return array(
+            'form' => $form->createView(),
+        );
     }
 }

--- a/src/Intracto/SecretSantaBundle/Entity/Pool.php
+++ b/src/Intracto/SecretSantaBundle/Entity/Pool.php
@@ -97,17 +97,16 @@ class Pool
     /**
      * Constructor
      */
-    public function __construct()
+    public function __construct($createDefaults = true)
     {
         $this->entries = new \Doctrine\Common\Collections\ArrayCollection();
 
-        // Create default minimum entries
-        for ($i = 0; $i < 3; $i++) {
-            $entry = new Entry();
-            if ($i == 0) {
-                $entry->setPoolAdmin(true);
+        if ($createDefaults) {
+            // Create default minimum entries
+            for ($i = 0; $i < 3; $i++) {
+                $entry = new Entry();
+                $this->addEntry($entry);
             }
-            $this->addEntry($entry);
         }
     }
 
@@ -396,5 +395,25 @@ class Pool
     public function getExposed()
     {
         return $this->exposed;
+    }
+
+    public function createNewForReuse()
+    {
+        $oldPool = $this;
+
+        $pool = new Pool(false);
+        $pool->setAmount($oldPool->getAmount());
+
+        $oldEntries = $oldPool->getEntries();
+
+        /** @var Entry $oldEntry */
+        foreach ($oldEntries as $oldEntry) {
+            $entry = new Entry();
+            $entry->setEmail($oldEntry->getEmail());
+            $entry->setName($oldEntry->getName());
+            $pool->addEntry($entry);
+        }
+
+        return $pool;
     }
 }

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -273,6 +273,8 @@ btn:
     expose: Send me all the matches
     expose_confirm: I understand the consequences, send my Secret Santa mailing list now
     cancel: Cancel
+    reuse: Reuse this list
+    reuse_info: Reuse this list to start a new list
 
 emails:
     sender: Santa Claus

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -254,6 +254,8 @@ btn:
     expose: Stuur me alle koppelingen
     expose_confirm: Ik begrijp de gevolgen, stuur mij nu alle koppelingen
     cancel: Annuleren
+    reuse: Hergebruik deze lijst
+    reuse_info: Hergebruik deze lijst voor een nieuwe lijst
 
 emails:
     sender: Kerstman

--- a/src/Intracto/SecretSantaBundle/Resources/views/Pool/create.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Pool/create.html.twig
@@ -25,7 +25,7 @@
         <div class="santa-content">
             <h1>{{ 'create.add_participants'|trans }}</h1>
 
-            <form action="{{ path('pool_create') }}#mysanta" method="POST" {{ form_enctype(form) }} novalidate>
+            <form action="#mysanta" method="POST" {{ form_enctype(form) }} novalidate>
                 {{ form_row(form._token) }}
                 <div class="row toplabels">
                     <div class="span4{% if form_errors(form.date) %} error{% endif %}">{{ form_label(form.date) }}{{ form_widget(form.date) }}</div>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Pool/manage.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Pool/manage.html.twig
@@ -4,6 +4,8 @@
 {% endblock %}
 {% block main %}
     <div class="box">
+        <a href="{{ path('pool_reuse', {'listUrl': pool.listUrl}) }}" class="btn btn-success pull-right"
+           title="{{ 'btn.reuse_info'|trans }}"><i class="icon-repeat icon-white"></i> {{ 'btn.reuse'|trans }}</a>
         <h1>{{ 'manage.title'|trans }}</h1>
         <table class="entries table table-striped" id="mysanta">
             <thead>
@@ -50,9 +52,10 @@
             <strong>{{ 'manage.tip'|trans }}</strong> {{ 'manage.come_back'|trans }}
         </div>
 
-        <button id="btn_delete" class="btn btn-primary"><i class="icon-warning-sign icon-white"></i> {{ 'btn.delete_list'|trans }}</button>
-        <button id="btn_expose" class="btn btn-warning"><i class="icon-eye-open icon-white"></i> {{ 'btn.expose'|trans }}</button>
-
+        <button id="btn_delete" class="btn btn-primary"><i
+                    class="icon-warning-sign icon-white"></i> {{ 'btn.delete_list'|trans }}</button>
+        <button id="btn_expose" class="btn btn-warning"><i
+                    class="icon-eye-open icon-white"></i> {{ 'btn.expose'|trans }}</button>
         <br/><br/>
 
         <div id="delete-warning" class="alert alert-error" style="display: none;">
@@ -94,24 +97,24 @@
 {% block javascripts %}
     {{ parent() }}
     <script type="text/javascript">
-        $( document ).ready(function() {
-            $('#btn_delete').click(function(e) {
+        $(document).ready(function () {
+            $('#btn_delete').click(function (e) {
                 $('#delete-warning').show();
                 $('#btn_delete').hide();
                 $('#delete-confirmation').focus();
             });
-            $('#btn_delete_cancel').click(function(e) {
+            $('#btn_delete_cancel').click(function (e) {
                 $('#delete-warning').hide();
                 $('#btn_delete').show().focus();
             });
 
-            $('#btn_expose').click(function(e) {
+            $('#btn_expose').click(function (e) {
                 $('#expose-warning').show();
                 $('#btn_expose').hide();
                 $('#expose-confirmation').focus();
             });
 
-            $('#btn_expose_cancel').click(function(e) {
+            $('#btn_expose_cancel').click(function (e) {
                 $('#expose-warning').hide();
                 $('#btn_expose').show().focus();
             });


### PR DESCRIPTION
Added a button on the manage page to reuse current list for a new pool.
It just loads the previous entries in the form so they can still alter it.

Btn needs to be translate to other languages.
Maybe also a section in the faq explaining this feature.
In combination of re-sending the lost admin url it is an easy to use feature that could come in handy for large pools.


Possible enhancements are to also remember the excludes and last years picks to the next step.
