### PR TITLE
2 problems with provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,12 @@
 
 VAGRANTFILE_API_VERSION = "2"
 
+module OS
+    def OS.windows?
+        (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+    end
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.define :secretsanta do |secretsanta_config|
         secretsanta_config.vm.box = "Debian75"
@@ -21,8 +27,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         # allow external connections to the machine
         #secretsanta_config.vm.network "forwarded_port", guest: 80, host: 8888
 
-        # Shared folder over NFS
-        secretsanta_config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: ['rw', 'vers=3', 'tcp', 'fsc' ,'actimeo=2']
+#        is_windows_host = "#{OS.windows?}"
+#        puts "is_windows_host: #{OS.windows?}"
+
+        # Shared folder over NFS unless Windows
+        if OS.windows?
+            secretsanta_config.vm.synced_folder ".", "/vagrant"
+        else
+            secretsanta_config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: ['rw', 'vers=3', 'tcp', 'fsc' ,'actimeo=2']
+        end
+
         #secretsanta_config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: [".git/", "web/bundles/", "app/cache", "app/logs"]
 
         secretsanta_config.vm.network "private_network", ip: "192.168.33.10"

--- a/shell_provisioner/module/php.sh
+++ b/shell_provisioner/module/php.sh
@@ -2,7 +2,7 @@
 
 # PHP
 
-apt-get -y install php5 php5-intl php5-xdebug
+apt-get -y install php5 php5-intl php5-xdebug php-apc
 
 # PHP config
 sed -i "s#;date.timezone =#date.timezone = Europe/Brussels#" /etc/php5/apache2/php.ini


### PR DESCRIPTION
2 problems:

1) PHP-APC package is not included in provisioner, but required for ApcClassLoader. Fixed by adding php-apc to shellprovisioning script

2) On Windows, mounting of shared folder fails when the additional NFS options are passed to the fallback vboxfs shared folder provider. Added an OS Check to the Vagrantfile that will use the appropriate command for Windows hosts.

