### PR TITLE
Added CSV import using jQuery-CSV plug-in, see #43 and #39

### DIFF
--- a/src/Intracto/SecretSantaBundle/Resources/public/css/update.css
+++ b/src/Intracto/SecretSantaBundle/Resources/public/css/update.css
@@ -336,3 +336,11 @@ ul.form-errors {
 .ui-sortable-helper {
     display: table;
 }
+
+.row-import-entries {
+    display: none;
+}
+.add-import-entry-data {
+    width: 100%;
+    height: 100px;
+}

--- a/src/Intracto/SecretSantaBundle/Resources/public/js/jquery.csv-0.71.min.js
+++ b/src/Intracto/SecretSantaBundle/Resources/public/js/jquery.csv-0.71.min.js
@@ -1,0 +1,73 @@
+
+RegExp.escape=function(s){return s.replace(/[-\/\\^$*+?.()|[\]{}]/g,'\\$&');};(function($){'use strict'
+$.csv={defaults:{separator:',',delimiter:'"',headers:true},hooks:{castToScalar:function(value,state){var hasDot=/\./;if(isNaN(value)){return value;}else{if(hasDot.test(value)){return parseFloat(value);}else{var integer=parseInt(value);if(isNaN(integer)){return null;}else{return integer;}}}}},parsers:{parse:function(csv,options){var separator=options.separator;var delimiter=options.delimiter;if(!options.state.rowNum){options.state.rowNum=1;}
+if(!options.state.colNum){options.state.colNum=1;}
+var data=[];var entry=[];var state=0;var value=''
+var exit=false;function endOfEntry(){state=0;value='';if(options.start&&options.state.rowNum<options.start){entry=[];options.state.rowNum++;options.state.colNum=1;return;}
+if(options.onParseEntry===undefined){data.push(entry);}else{var hookVal=options.onParseEntry(entry,options.state);if(hookVal!==false){data.push(hookVal);}}
+entry=[];if(options.end&&options.state.rowNum>=options.end){exit=true;}
+options.state.rowNum++;options.state.colNum=1;}
+function endOfValue(){if(options.onParseValue===undefined){entry.push(value);}else{var hook=options.onParseValue(value,options.state);if(hook!==false){entry.push(hook);}}
+value='';state=0;options.state.colNum++;}
+var escSeparator=RegExp.escape(separator);var escDelimiter=RegExp.escape(delimiter);var match=/(D|S|\n|\r|[^DS\r\n]+)/;var matchSrc=match.source;matchSrc=matchSrc.replace(/S/g,escSeparator);matchSrc=matchSrc.replace(/D/g,escDelimiter);match=RegExp(matchSrc,'gm');csv.replace(match,function(m0){if(exit){return;}
+switch(state){case 0:if(m0===separator){value+='';endOfValue();break;}
+if(m0===delimiter){state=1;break;}
+if(m0==='\n'){endOfValue();endOfEntry();break;}
+if(/^\r$/.test(m0)){break;}
+value+=m0;state=3;break;case 1:if(m0===delimiter){state=2;break;}
+value+=m0;state=1;break;case 2:if(m0===delimiter){value+=m0;state=1;break;}
+if(m0===separator){endOfValue();break;}
+if(m0==='\n'){endOfValue();endOfEntry();break;}
+if(/^\r$/.test(m0)){break;}
+throw new Error('CSVDataError: Illegal State [Row:'+options.state.rowNum+'][Col:'+options.state.colNum+']');case 3:if(m0===separator){endOfValue();break;}
+if(m0==='\n'){endOfValue();endOfEntry();break;}
+if(/^\r$/.test(m0)){break;}
+if(m0===delimiter){throw new Error('CSVDataError: Illegal Quote [Row:'+options.state.rowNum+'][Col:'+options.state.colNum+']');}
+throw new Error('CSVDataError: Illegal Data [Row:'+options.state.rowNum+'][Col:'+options.state.colNum+']');default:throw new Error('CSVDataError: Unknown State [Row:'+options.state.rowNum+'][Col:'+options.state.colNum+']');}});if(entry.length!==0){endOfValue();endOfEntry();}
+return data;},splitLines:function(csv,options){var separator=options.separator;var delimiter=options.delimiter;if(!options.state.rowNum){options.state.rowNum=1;}
+var entries=[];var state=0;var entry='';var exit=false;function endOfLine(){state=0;if(options.start&&options.state.rowNum<options.start){entry='';options.state.rowNum++;return;}
+if(options.onParseEntry===undefined){entries.push(entry);}else{var hookVal=options.onParseEntry(entry,options.state);if(hookVal!==false){entries.push(hookVal);}}
+entry='';if(options.end&&options.state.rowNum>=options.end){exit=true;}
+options.state.rowNum++;}
+var escSeparator=RegExp.escape(separator);var escDelimiter=RegExp.escape(delimiter);var match=/(D|S|\n|\r|[^DS\r\n]+)/;var matchSrc=match.source;matchSrc=matchSrc.replace(/S/g,escSeparator);matchSrc=matchSrc.replace(/D/g,escDelimiter);match=RegExp(matchSrc,'gm');csv.replace(match,function(m0){if(exit){return;}
+switch(state){case 0:if(m0===separator){entry+=m0;state=0;break;}
+if(m0===delimiter){entry+=m0;state=1;break;}
+if(m0==='\n'){endOfLine();break;}
+if(/^\r$/.test(m0)){break;}
+entry+=m0;state=3;break;case 1:if(m0===delimiter){entry+=m0;state=2;break;}
+entry+=m0;state=1;break;case 2:var prevChar=entry.substr(entry.length-1);if(m0===delimiter&&prevChar===delimiter){entry+=m0;state=1;break;}
+if(m0===separator){entry+=m0;state=0;break;}
+if(m0==='\n'){endOfLine();break;}
+if(m0==='\r'){break;}
+throw new Error('CSVDataError: Illegal state [Row:'+options.state.rowNum+']');case 3:if(m0===separator){entry+=m0;state=0;break;}
+if(m0==='\n'){endOfLine();break;}
+if(m0==='\r'){break;}
+if(m0===delimiter){throw new Error('CSVDataError: Illegal quote [Row:'+options.state.rowNum+']');}
+throw new Error('CSVDataError: Illegal state [Row:'+options.state.rowNum+']');default:throw new Error('CSVDataError: Unknown state [Row:'+options.state.rowNum+']');}});if(entry!==''){endOfLine();}
+return entries;},parseEntry:function(csv,options){var separator=options.separator;var delimiter=options.delimiter;if(!options.state.rowNum){options.state.rowNum=1;}
+if(!options.state.colNum){options.state.colNum=1;}
+var entry=[];var state=0;var value='';function endOfValue(){if(options.onParseValue===undefined){entry.push(value);}else{var hook=options.onParseValue(value,options.state);if(hook!==false){entry.push(hook);}}
+value='';state=0;options.state.colNum++;}
+if(!options.match){var escSeparator=RegExp.escape(separator);var escDelimiter=RegExp.escape(delimiter);var match=/(D|S|\n|\r|[^DS\r\n]+)/;var matchSrc=match.source;matchSrc=matchSrc.replace(/S/g,escSeparator);matchSrc=matchSrc.replace(/D/g,escDelimiter);options.match=RegExp(matchSrc,'gm');}
+csv.replace(options.match,function(m0){switch(state){case 0:if(m0===separator){value+='';endOfValue();break;}
+if(m0===delimiter){state=1;break;}
+if(m0==='\n'||m0==='\r'){break;}
+value+=m0;state=3;break;case 1:if(m0===delimiter){state=2;break;}
+value+=m0;state=1;break;case 2:if(m0===delimiter){value+=m0;state=1;break;}
+if(m0===separator){endOfValue();break;}
+if(m0==='\n'||m0==='\r'){break;}
+throw new Error('CSVDataError: Illegal State [Row:'+options.state.rowNum+'][Col:'+options.state.colNum+']');case 3:if(m0===separator){endOfValue();break;}
+if(m0==='\n'||m0==='\r'){break;}
+if(m0===delimiter){throw new Error('CSVDataError: Illegal Quote [Row:'+options.state.rowNum+'][Col:'+options.state.colNum+']');}
+throw new Error('CSVDataError: Illegal Data [Row:'+options.state.rowNum+'][Col:'+options.state.colNum+']');default:throw new Error('CSVDataError: Unknown State [Row:'+options.state.rowNum+'][Col:'+options.state.colNum+']');}});endOfValue();return entry;}},toArray:function(csv,options,callback){var options=(options!==undefined?options:{});var config={};config.callback=((callback!==undefined&&typeof(callback)==='function')?callback:false);config.separator='separator'in options?options.separator:$.csv.defaults.separator;config.delimiter='delimiter'in options?options.delimiter:$.csv.defaults.delimiter;var state=(options.state!==undefined?options.state:{});var options={delimiter:config.delimiter,separator:config.separator,onParseEntry:options.onParseEntry,onParseValue:options.onParseValue,state:state}
+var entry=$.csv.parsers.parseEntry(csv,options);if(!config.callback){return entry;}else{config.callback('',entry);}},toArrays:function(csv,options,callback){var options=(options!==undefined?options:{});var config={};config.callback=((callback!==undefined&&typeof(callback)==='function')?callback:false);config.separator='separator'in options?options.separator:$.csv.defaults.separator;config.delimiter='delimiter'in options?options.delimiter:$.csv.defaults.delimiter;var data=[];var options={delimiter:config.delimiter,separator:config.separator,onParseEntry:options.onParseEntry,onParseValue:options.onParseValue,start:options.start,end:options.end,state:{rowNum:1,colNum:1}};data=$.csv.parsers.parse(csv,options);if(!config.callback){return data;}else{config.callback('',data);}},toObjects:function(csv,options,callback){var options=(options!==undefined?options:{});var config={};config.callback=((callback!==undefined&&typeof(callback)==='function')?callback:false);config.separator='separator'in options?options.separator:$.csv.defaults.separator;config.delimiter='delimiter'in options?options.delimiter:$.csv.defaults.delimiter;config.headers='headers'in options?options.headers:$.csv.defaults.headers;options.start='start'in options?options.start:1;if(config.headers){options.start++;}
+if(options.end&&config.headers){options.end++;}
+var lines=[];var data=[];var options={delimiter:config.delimiter,separator:config.separator,onParseEntry:options.onParseEntry,onParseValue:options.onParseValue,start:options.start,end:options.end,state:{rowNum:1,colNum:1},match:false};var headerOptions={delimiter:config.delimiter,separator:config.separator,start:1,end:1,state:{rowNum:1,colNum:1}}
+var headerLine=$.csv.parsers.splitLines(csv,headerOptions);var headers=$.csv.toArray(headerLine[0],options);var lines=$.csv.parsers.splitLines(csv,options);options.state.colNum=1;if(headers){options.state.rowNum=2;}else{options.state.rowNum=1;}
+for(var i=0,len=lines.length;i<len;i++){var entry=$.csv.toArray(lines[i],options);var object={};for(var j in headers){object[headers[j]]=entry[j];}
+data.push(object);options.state.rowNum++;}
+if(!config.callback){return data;}else{config.callback('',data);}},fromArrays:function(arrays,options,callback){var options=(options!==undefined?options:{});var config={};config.callback=((callback!==undefined&&typeof(callback)==='function')?callback:false);config.separator='separator'in options?options.separator:$.csv.defaults.separator;config.delimiter='delimiter'in options?options.delimiter:$.csv.defaults.delimiter;config.escaper='escaper'in options?options.escaper:$.csv.defaults.escaper;config.experimental='experimental'in options?options.experimental:false;if(!config.experimental){throw new Error('not implemented');}
+var output=[];for(i in arrays){output.push(arrays[i]);}
+if(!config.callback){return output;}else{config.callback('',output);}},fromObjects2CSV:function(objects,options,callback){var options=(options!==undefined?options:{});var config={};config.callback=((callback!==undefined&&typeof(callback)==='function')?callback:false);config.separator='separator'in options?options.separator:$.csv.defaults.separator;config.delimiter='delimiter'in options?options.delimiter:$.csv.defaults.delimiter;config.experimental='experimental'in options?options.experimental:false;if(!config.experimental){throw new Error('not implemented');}
+var output=[];for(i in objects){output.push(arrays[i]);}
+if(!config.callback){return output;}else{config.callback('',output);}}};$.csvEntry2Array=$.csv.toArray;$.csv2Array=$.csv.toArrays;$.csv2Dictionary=$.csv.toObjects;})(jQuery);

--- a/src/Intracto/SecretSantaBundle/Resources/public/js/pool.create.js
+++ b/src/Intracto/SecretSantaBundle/Resources/public/js/pool.create.js
@@ -1,4 +1,4 @@
-function addNewEntry(collectionHolder) {
+function addNewEntry(collectionHolder, email, name) {
     // Get entry prototype as defined in attribute data-prototype
     var prototype = collectionHolder.attr('data-prototype');
     // Adjust entry prototype for correct naming
@@ -8,7 +8,15 @@ function addNewEntry(collectionHolder) {
     // Add new entry to pool with animation
     var newForm = $(newFormHtml);
     collectionHolder.append(newForm);
-    newForm.show(300);
+    if ( (typeof(email)!=='undefined') && (typeof(name)!=='undefined') ) {
+        // email and name provided, fill in the blanks
+        $(newForm).find('.entry-mail').attr('value', email);
+        $(newForm).find('.entry-name').attr('value', name);
+        newForm.show();
+    } else {
+        newForm.show(300);
+    }
+
 
     // Handle delete button events
     bindDeleteButtonEvents();

--- a/src/Intracto/SecretSantaBundle/Resources/public/js/pool.import.js
+++ b/src/Intracto/SecretSantaBundle/Resources/public/js/pool.import.js
@@ -1,0 +1,84 @@
+
+/* Variables */
+var collectionHolder = $('table.entries tbody');
+
+/* Document Ready */
+jQuery(document).ready(function() {
+
+    //Add eventlistener on add-new-entry button
+    $('.add-import-entry').click(function(e) {
+        e.preventDefault();
+        $('.row-import-entries').show(300);
+    });
+
+    $('.btn-import-cancel').click(function(e) {
+        e.preventDefault();
+        $('.row-import-entries').hide(300);
+    });
+
+    $('.add-import-entry-do').click(function(e) {
+        e.preventDefault();
+
+        var entries = $.csv.toArrays($('.add-import-entry-data').val(), {headers: false, seperator: ',', delimiter: '"' } );
+
+        if(typeof(entries[0]) === 'undefined') {
+            return;
+        }
+
+        var added = 0; var lookForEmpty = true;
+        for(var entry in entries) {
+
+            var email = '';
+            var name = '';
+
+            for(var field in entries[entry]) {
+                // very basic check, can/should probably be done some other way
+                // check if this is an e-mailaddress
+                if (email == '' && entries[entry][field].indexOf('@') != -1) {
+                    email = entries[entry][field];
+                } else {
+                    // either e-mail already found, or no @ sign found
+                    name = entries[entry][field];
+                }
+            }
+
+            if (email != '') {
+                if (name == '') name = email;
+
+                // check to see if list contains empty entries
+                if (lookForEmpty) {
+                    // if so, use them, otherwise add new
+                    elem = $(collectionHolder).find('.entry-name[value=""],.entry-name:not([value])');
+                    if (elem.length > 0) {
+                        row = $(elem[0]).parent().parent();
+                        $(row).find('.entry-name').attr('value', name);
+                        $(row).find('.entry-mail').attr('value', email);
+                    } else {
+                        // prevent lookup on next iteration
+                        lookForEmpty = false;
+                        addNewEntry(collectionHolder, email, name);
+                    }
+                } else {
+                    addNewEntry(collectionHolder, email, name);
+                }
+                added++;
+            }
+
+        }
+
+        if (added > 0) {
+            $('.add-import-entry-data').val('');
+            $('.row-import-entries').hide(300);
+        }
+
+    });
+
+    $('.add-import-entry-data').change(function() {
+        // replace tab and ; delimiter with ,
+        data = $(this).val().replace(/\t/g, ",").replace(/;/g, ",");
+        if (data != $(this).text()) {
+            $(this).val(data);
+        }
+    });
+
+});

--- a/src/Intracto/SecretSantaBundle/Resources/views/Pool/create.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Pool/create.html.twig
@@ -44,7 +44,24 @@
                             <button type="button" class="btn btn-mini btn-success add-new-entry"><i
                                         class="icon-plus-sign icon-white"></i> {{ 'btn.add_person'|trans }}
                             </button>
+                            <button type="button" class="btn btn-mini btn-success add-import-entry"><i
+                                        class="icon-plus-sign icon-white"></i> {{ 'btn.import_persons'|trans }}
+                            </button>
                         </th>
+                    </tr>
+                    <tr class="row-import-entries">
+                        <td />
+                        <td colspan="2">
+                            <div>{{ 'create.import.instructions' |trans }}</div>
+                            <textarea class="add-import-entry-data"></textarea>
+                            <br />
+                            <button type="button" class="btn btn-mini btn-success add-import-entry-do"><i
+                                        class="icon-plus-sign icon-white"></i> {{ 'btn.import_persons.do'|trans }}
+                            </button>
+                            <button type="button" class="btn btn-mini btn-danger btn-import-cancel"><i
+                                        class="icon-minus-sign icon-white"></i> {{ 'btn.import_persons.cancel'|trans }}
+                            </button>
+                        </td>
                     </tr>
                     </thead>
                     <tbody data-prototype="{% filter escape %}{% include 'IntractoSecretSantaBundle:Helpers:prototypeEntry.html.twig' with {'entry': form.entries.vars['prototype']} %}{% endfilter %}">
@@ -144,7 +161,9 @@
 {% block javascripts %}
     {% javascripts
         '@IntractoSecretSantaBundle/Resources/public/js/jquery.smooth-scroll.min.js'
-        '@IntractoSecretSantaBundle/Resources/public/js/pool.create.js' %}
+        '@IntractoSecretSantaBundle/Resources/public/js/jquery.csv-0.71.min.js'
+        '@IntractoSecretSantaBundle/Resources/public/js/pool.create.js'
+        '@IntractoSecretSantaBundle/Resources/public/js/pool.import.js' %}
         <script type="text/javascript" src="{{ asset_url }}"></script>
     {% endjavascripts %}
     {{ form_javascript(form) }}


### PR DESCRIPTION
Full JS solution, no server-side processing

Allows the user to copy/paste e-mail/name value pairs.
Replaces common seperators tab and semicolon with comma for consitent import so that you can paste directly from Excel.

Still needs some work though (labels, trans, info, ...)

Known issues:
- when processing a large number of records, browser appears to be frozen for a number of seconds
- when adding a large number of entries (+500), the server will run into the default max_input_vars limit of PHP. Make sure to accomodate your server config for this. (should we limit this in the page?)

