### PR TITLE
Temporary fix for #41 - memory issue with reminder e-mails

### DIFF
--- a/src/Intracto/SecretSantaBundle/Command/MailqueueCommand.php
+++ b/src/Intracto/SecretSantaBundle/Command/MailqueueCommand.php
@@ -53,7 +53,7 @@ class MailqueueCommand extends ContainerAwareCommand
          * @var EntryRepository $entryRepository
          */
         $entryRepository = $em->getRepository('IntractoSecretSantaBundle:Entry');
-        $secret_santas = $entryRepository->findAllForWishlistNofifcication();
+        $secret_santas = $entryRepository->findBatchForWishlistNofifcication();
 
         $container = $this->getContainer();
         $mailer = $container->get('mailer');
@@ -93,12 +93,17 @@ class MailqueueCommand extends ContainerAwareCommand
 
             if ($input->getArgument('force')) {
                 $mailer->send($message);
-                $spool->flushQueue($transport);
-
                 $receiver->setWishlistUpdated(false);
-                $em->flush($receiver);
+                $em->persist($receiver);
             }
             echo '.';
         }
+
+        if ($input->getArgument('force')) {
+            // flush queue and entitymanager
+            $spool->flushQueue($transport);
+            $em->flush();
+        }
+
     }
 }

--- a/src/Intracto/SecretSantaBundle/Command/MailqueueCommand.php
+++ b/src/Intracto/SecretSantaBundle/Command/MailqueueCommand.php
@@ -53,7 +53,7 @@ class MailqueueCommand extends ContainerAwareCommand
          * @var EntryRepository $entryRepository
          */
         $entryRepository = $em->getRepository('IntractoSecretSantaBundle:Entry');
-        $secret_santas = $entryRepository->findBatchForWishlistNofifcication();
+        $secret_santas = $entryRepository->findBatchForWishlistNotification();
 
         $container = $this->getContainer();
         $mailer = $container->get('mailer');

--- a/src/Intracto/SecretSantaBundle/Command/SendBatchMailsCommand.php
+++ b/src/Intracto/SecretSantaBundle/Command/SendBatchMailsCommand.php
@@ -25,6 +25,20 @@ class SendBatchMailsCommand extends ContainerAwareCommand
                 null,
                 InputOption::VALUE_NONE,
                 'If not set, a trial run will execute. No mails will be actually sent'
+            )
+            ->addOption(
+                'batch-size',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Send this amount of messages at a time (defaults to 10)',
+                10
+            )
+            ->addOption(
+                'time-limit',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Stop processing after this amount of seconds. If not given, a single batch is processed.',
+                0
             );
     }
 
@@ -47,13 +61,27 @@ class SendBatchMailsCommand extends ContainerAwareCommand
 
         $mailer->setOutput($output);
 
-        $mailer->sendBatchMails(
-            $this->getContainer()->getParameter('admin_email'),
-            [
-                new BatchViewEntryReminder(),
-                new BatchEmptyWishlistReminder(),
-            ],
-            $input->getOption('force')
-        );
+        $batchSize = $input->getOption("batch-size");
+        $timeLimit = $input->getOption("time-limit");
+
+        if (!is_numeric($batchSize) || $batchSize < 1) throw new \LogicException("batch size invalid");
+        if (!is_numeric($timeLimit) || $timeLimit < 0) throw new \LogicException("timelimit invalid");
+
+        $started = time();
+        do {
+            $mailer->sendBatchMails(
+                $this->getContainer()->getParameter('admin_email'),
+                [
+                    new BatchViewEntryReminder($batchSize),
+                    new BatchEmptyWishlistReminder($batchSize),
+                ],
+                $input->getOption('force')
+            );
+
+            // pause a bit
+            sleep(5);
+
+        } while ($timeLimit > (time() - $started));
+
     }
 }

--- a/src/Intracto/SecretSantaBundle/Command/SendBatchMailsCommand.php
+++ b/src/Intracto/SecretSantaBundle/Command/SendBatchMailsCommand.php
@@ -73,7 +73,7 @@ class SendBatchMailsCommand extends ContainerAwareCommand
                 $this->getContainer()->getParameter('admin_email'),
                 [
                     new BatchViewEntryReminder($batchSize),
-                    new BatchEmptyWishlistReminder($batchSize),
+//                    new BatchEmptyWishlistReminder($batchSize),
                 ],
                 $input->getOption('force')
             );

--- a/src/Intracto/SecretSantaBundle/Entity/EntryRepository.php
+++ b/src/Intracto/SecretSantaBundle/Entity/EntryRepository.php
@@ -39,7 +39,7 @@ class EntryRepository extends EntityRepository
     /**
      * @return Entry[]
      */
-    public function findBatchForWishlistNofifcication($batchSize = 50)
+    public function findBatchForWishlistNotification($batchSize = 50)
     {
         $query = $this->_em->createQuery('
             SELECT entry

--- a/src/Intracto/SecretSantaBundle/Entity/EntryRepository.php
+++ b/src/Intracto/SecretSantaBundle/Entity/EntryRepository.php
@@ -37,6 +37,21 @@ class EntryRepository extends EntityRepository
     }
 
     /**
+     * @return Entry[]
+     */
+    public function findBatchForWishlistNofifcication($batchSize = 50)
+    {
+        $query = $this->_em->createQuery('
+            SELECT entry
+            FROM IntractoSecretSantaBundle:Entry entry
+            JOIN entry.entry peer
+            WHERE peer.wishlist_updated = 1
+        ')->setMaxResults($batchSize);
+
+        return $query->getResult();
+    }
+
+    /**
      * Find all entries that haven't been watched yet in Pools which were sent
      * out more than two weeks ago and the party date is max six weeks in the
      * future.
@@ -69,6 +84,39 @@ class EntryRepository extends EntityRepository
     }
 
     /**
+     * Find number of entries that haven't been watched yet in Pools which were sent
+     * out more than two weeks ago and the party date is max six weeks in the
+     * future.
+     *
+     * @return Entry[]
+     */
+    public function findBatchToRemindToViewEntry($batchSize)
+    {
+        $today = new \DateTime();
+        $twoWeeksAgo = new \DateTime('now - 2 weeks');
+        $sixWeeksFromNow = new \DateTime('now + 6 weeks');
+
+        $query = $this->_em->createQuery('
+            SELECT entry
+            FROM IntractoSecretSantaBundle:Entry entry
+              JOIN entry.pool pool
+            WHERE entry.viewdate IS NULL
+              AND entry.url IS NOT NULL
+              AND pool.created = 1
+              AND pool.date > :today
+              AND pool.date < :sixWeeksFromNow
+              AND pool.sentdate < :twoWeeksAgo
+              AND (entry.viewReminderSentTime IS NULL OR entry.viewReminderSentTime < :twoWeeksAgo)
+        ')->setMaxResults($batchSize);
+
+        $query->setParameter('today', $today, \Doctrine\DBAL\Types\Type::DATETIME);
+        $query->setParameter('twoWeeksAgo', $twoWeeksAgo, \Doctrine\DBAL\Types\Type::DATETIME);
+        $query->setParameter('sixWeeksFromNow', $sixWeeksFromNow, \Doctrine\DBAL\Types\Type::DATETIME);
+
+        return $query->getResult();
+    }
+
+    /**
      * Find all entries that havean empty wishlit in Pools which were sent out
      * more than two weeks ago and the party date is max six weeks in the future.
      *
@@ -91,6 +139,38 @@ class EntryRepository extends EntityRepository
               AND pool.sentdate < :twoWeeksAgo
               AND (entry.updateWishlistReminderSentTime IS NULL OR entry.updateWishlistReminderSentTime < :twoWeeksAgo)
         ');
+
+        $query->setParameter('today', $today, \Doctrine\DBAL\Types\Type::DATETIME);
+        $query->setParameter('twoWeeksAgo', $twoWeeksAgo, \Doctrine\DBAL\Types\Type::DATETIME);
+        $query->setParameter('sixWeeksFromNow', $sixWeeksFromNow, \Doctrine\DBAL\Types\Type::DATETIME);
+
+        return $query->getResult();
+    }
+
+    /**
+     * Find number of entries that havean empty wishlit in Pools which were sent out
+     * more than two weeks ago and the party date is max six weeks in the future.
+     *
+     * @return Entry[]
+     */
+    public function findBatchToRemindOfEmptyWishlist($batchSize)
+    {
+        $today = new \DateTime();
+        $twoWeeksAgo = new \DateTime('now - 2 weeks');
+        $sixWeeksFromNow = new \DateTime('now + 6 weeks');
+
+        $query = $this->_em->createQuery('
+            SELECT entry
+            FROM IntractoSecretSantaBundle:Entry entry
+              JOIN entry.pool pool
+            WHERE entry.wishlist_updated = 0
+              AND entry.url IS NOT NULL
+              AND pool.created = 1
+              AND pool.date > :today
+              AND pool.date < :sixWeeksFromNow
+              AND pool.sentdate < :twoWeeksAgo
+              AND (entry.updateWishlistReminderSentTime IS NULL OR entry.updateWishlistReminderSentTime < :twoWeeksAgo)
+        ')->setMaxResults($batchSize);
 
         $query->setParameter('today', $today, \Doctrine\DBAL\Types\Type::DATETIME);
         $query->setParameter('twoWeeksAgo', $twoWeeksAgo, \Doctrine\DBAL\Types\Type::DATETIME);

--- a/src/Intracto/SecretSantaBundle/Mailer/Mail/BatchEmptyWishlistReminder.php
+++ b/src/Intracto/SecretSantaBundle/Mailer/Mail/BatchEmptyWishlistReminder.php
@@ -13,6 +13,16 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class BatchEmptyWishlistReminder implements BatchEntryMail
 {
+    private $batchSize;
+
+    /**
+     * BatchViewEntryReminder constructor.
+     */
+    public function __construct($batchSize)
+    {
+        $this->batchSize = $batchSize;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -31,7 +41,7 @@ class BatchEmptyWishlistReminder implements BatchEntryMail
          */
         $entryRepository = $entityManager->getRepository('IntractoSecretSantaBundle:Entry');
 
-        return $entryRepository->findAllToRemindOfEmptyWishlist();
+        return $entryRepository->findBatchToRemindOfEmptyWishlist($this->batchSize);
     }
 
     /**

--- a/src/Intracto/SecretSantaBundle/Mailer/Mail/BatchEntryMail.php
+++ b/src/Intracto/SecretSantaBundle/Mailer/Mail/BatchEntryMail.php
@@ -11,6 +11,9 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 interface BatchEntryMail
 {
+
+    public function __construct($batchSize);
+
     /**
      * @return string
      */

--- a/src/Intracto/SecretSantaBundle/Mailer/Mail/BatchViewEntryReminder.php
+++ b/src/Intracto/SecretSantaBundle/Mailer/Mail/BatchViewEntryReminder.php
@@ -13,6 +13,18 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class BatchViewEntryReminder implements BatchEntryMail
 {
+
+    private $batchSize;
+
+    /**
+     * BatchViewEntryReminder constructor.
+     */
+    public function __construct($batchSize)
+    {
+        $this->batchSize = $batchSize;
+    }
+
+
     /**
      * {@inheritdoc}
      */
@@ -31,7 +43,7 @@ class BatchViewEntryReminder implements BatchEntryMail
          */
         $entryRepository = $entityManager->getRepository('IntractoSecretSantaBundle:Entry');
 
-        return $entryRepository->findAllToRemindToViewEntry();
+        return $entryRepository->findBatchToRemindToViewEntry($this->batchSize);
     }
 
     /**

--- a/src/Intracto/SecretSantaBundle/Mailer/Mailer.php
+++ b/src/Intracto/SecretSantaBundle/Mailer/Mailer.php
@@ -105,14 +105,20 @@ class Mailer
 
                 if ($doSend) {
                     $this->mailer->send($message);
-                    $spool->flushQueue($this->transport);
-
                     $batchMail->handleMailSent($receiver, $this->em);
                 }
             } catch (\Exception $e) {
                 $this->writeOutput(sprintf('<error>An error occurred while sending mail for email "%s"</error>', $receiver->getEmail()));
+                // mark as handled, as otherwise the system will keep retrying over and over again
+                $batchMail->handleMailSent($receiver, $this->em);
             }
         }
+
+        if ($doSend) {
+            // only flush queue at the end of a batch
+            $spool->flushQueue($this->transport);
+        }
+
     }
 
     /**


### PR DESCRIPTION
- limit the number of entries handled at a time, drasticly reduces the
  time and memory the entitymanager needs to process the updates.
- command had a --time-limit option that will make the command stop after
  a number of seconds.

eg. The following command could be used in combination with a crontab set
to run each minute

php app/console intracto:mails:reminders:send --time-limit=50 --force

Entries are processed in batches (default 10, configurable) and a single flush of the spool is done at the end of the batch. Keeping batches small is advised (run more often with smaller batches).

A permanent fix/rewrite of the batch e-mail system is also in the make (enhancement for 2016?).