### PR TITLE
Report caching

### DIFF
--- a/src/Intracto/SecretSantaBundle/Controller/ReportController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/ReportController.php
@@ -18,9 +18,9 @@ class ReportController extends Controller
         $report = $this->get('intracto_secret_santa.report');
         $comparison = $this->get('intracto_secret_santa.season_comparison');
 
-        if ($reportQueryResult = $this->get('cache')->fetch('dataP' . $year)) {
+        if ($reportQueryResult = $this->get('cache')->fetch('data' . $year)) {
             $cache = unserialize($reportQueryResult);
-            
+
             $data = [
                 'current_year' => $year,
                 'data_pool' => $cache['data_pool'],
@@ -74,7 +74,7 @@ class ReportController extends Controller
             $data['difference_data_pool'] = $differenceDataPool;
         }
 
-        $this->get('cache')->save('dataP' . $year, serialize($data), 86400);
+        $this->get('cache')->save('data' . $year, serialize($data), 86400);
 
         return $data;
     }

--- a/src/Intracto/SecretSantaBundle/Controller/ReportController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/ReportController.php
@@ -19,11 +19,15 @@ class ReportController extends Controller
         $comparison = $this->get('intracto_secret_santa.season_comparison');
 
         try {
-            if ($year != 'all') {
-                $dataPool = $report->getPoolReport($year);
-                $differenceDataPool = $comparison->getComparison($year);
+            if ($reportQueryResult = $this->get('cache')->fetch('dataPool' . $year)) {
+                $dataPool = unserialize($reportQueryResult);
             } else {
-                $dataPool = $report->getPoolReport();
+                if ($year != 'all') {
+                    $dataPool = $report->getPoolReport($year);
+                } else {
+                    $dataPool = $report->getFullPoolReport();
+                }
+                $this->get('cache')->save('dataPool' . $year, serialize($dataPool), 86400);
             }
         } catch (\Exception $e) {
             $dataPool = [];

--- a/src/Intracto/SecretSantaBundle/Resources/views/Report/report.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Report/report.html.twig
@@ -219,37 +219,43 @@
             </div>
         {% endif %}
 
-        <div class="col-xs-12 col-md-6 report">
-            <div class="report_inside">
-                <h3>{{ 'report.visitors_per_country'|trans }}</h3>
+        {% if google_data_pool is not empty %}
+            <div class="col-xs-12 col-md-6 report">
+                <div class="report_inside">
+                    <h3>{{ 'report.visitors_per_country'|trans }}</h3>
 
-                <div id="country_chart" style="width: 100%"></div>
+                    <div id="country_chart" style="width: 100%"></div>
+                </div>
             </div>
-        </div>
 
-        <div class="col-xs-12 col-md-6 report">
-            <div class="report_inside">
-                <h3>{{ 'report.visitors_per_language'|trans }}</h3>
+            <div class="col-xs-12 col-md-6 report">
+                <div class="report_inside">
+                    <h3>{{ 'report.visitors_per_language'|trans }}</h3>
 
-                <div id="language_chart" style="width: 100%"></div>
+                    <div id="language_chart" style="width: 100%"></div>
+                </div>
             </div>
-        </div>
 
-        <div class="col-xs-12 col-md-6 report">
-            <div class="report_inside">
-                <h3>{{ 'report.mobile_usage'|trans }}</h3>
+            <div class="col-xs-12 col-md-6 report">
+                <div class="report_inside">
+                    <h3>{{ 'report.mobile_usage'|trans }}</h3>
 
-                <div id="device_chart" style="width: 100%"></div>
+                    <div id="device_chart" style="width: 100%"></div>
+                </div>
             </div>
-        </div>
 
-        <div class="col-xs-12 col-md-6 report">
-            <div class="report_inside">
-                <h3>{{ 'report.top_browser'|trans }}</h3>
+            <div class="col-xs-12 col-md-6 report">
+                <div class="report_inside">
+                    <h3>{{ 'report.top_browser'|trans }}</h3>
 
-                <div id="browser_chart" style="width: 100%"></div>
+                    <div id="browser_chart" style="width: 100%"></div>
+                </div>
             </div>
-        </div>
+        {% else %}
+            <div>
+                <p>{{ 'report.no_data'|trans }}</p>
+            </div>
+        {% endif %}
 
         <div class="clearfix"></div>
     {% endif %}


### PR DESCRIPTION
Subissue of #61

Added one day caching to reports. Every season has the possibility to be cached, also 'all time'-data will be cached, prevents long loading times and excess API calls.