### PR TITLE
Added comparison with previous season | Larger charts

### DIFF
--- a/src/Intracto/SecretSantaBundle/Controller/ReportController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/ReportController.php
@@ -47,7 +47,7 @@ class ReportController extends Controller
             'google_data_pool' => $googleDataPool,
         ];
 
-        if(isset($differenceDataPool)) {
+        if (isset($differenceDataPool)) {
             $data['difference_data_pool'] = $differenceDataPool;
         }
 

--- a/src/Intracto/SecretSantaBundle/Controller/ReportController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/ReportController.php
@@ -10,30 +10,30 @@ use Symfony\Component\HttpFoundation\Request;
 class ReportController extends Controller
 {
     /**
-     * @Route("/report", name="report")
+     * @Route("/report/{year}", defaults={"year" = "all"}, name="report")
      * @Template()
      */
-    public function reportAction(Request $request)
+    public function reportAction($year)
     {
         $analyticsQuery = $this->get('intracto_secret_santa.analytics');
         $report = $this->get('intracto_secret_santa.report');
         $comparison = $this->get('intracto_secret_santa.season_comparison');
-        $currentYear = $request->get('year', 'all');
 
         try {
-            if ($currentYear != 'all') {
-                $dataPool = $report->getPoolReport($currentYear);
-                $differenceDataPool = $comparison->getComparison($currentYear);
+            if ($year != 'all') {
+                $dataPool = $report->getPoolReport($year);
+                $differenceDataPool = $comparison->getComparison($year);
             } else {
                 $dataPool = $report->getPoolReport();
             }
         } catch (\Exception $e) {
             $dataPool = [];
+            $differenceDataPool = [];
         }
 
         try {
-            if ($currentYear != 'all') {
-                $googleDataPool = $analyticsQuery->getAnalyticsReport($currentYear);
+            if ($year != 'all') {
+                $googleDataPool = $analyticsQuery->getAnalyticsReport($year);
             } else {
                 $googleDataPool = $analyticsQuery->getAnalyticsReport();
             }
@@ -42,7 +42,7 @@ class ReportController extends Controller
         }
 
         $data = [
-            'current_year' => $currentYear,
+            'current_year' => $year,
             'data_pool' => $dataPool,
             'featured_years' => $this->get('intracto_secret_santa.featured_years')->getFeaturedYears(),
             'google_data_pool' => $googleDataPool,

--- a/src/Intracto/SecretSantaBundle/Controller/ReportController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/ReportController.php
@@ -15,20 +15,22 @@ class ReportController extends Controller
      */
     public function reportAction(Request $request)
     {
-        $reportQuery = $this->get('intracto_secret_santa.report');
         $analyticsQuery = $this->get('intracto_secret_santa.analytics');
+        $report = $this->get('intracto_secret_santa.report');
+        $comparison = $this->get('intracto_secret_santa.season_comparison');
         $currentYear = $request->get('year', 'all');
 
         try {
             if ($currentYear != 'all') {
-                $dataPool = $reportQuery->getPoolReport($currentYear);
-
+                $dataPool = $report->getPoolReport($currentYear);
+                $differenceDataPool = $comparison->getComparison($currentYear);
             } else {
-                $dataPool = $reportQuery->getPoolReport();
-
+                $dataPool = $report->getPoolReport();
+                $differenceDataPool = [];
             }
         } catch (\Exception $e) {
             $dataPool = [];
+            $differenceDataPool = [];
         }
 
         try {
@@ -46,6 +48,7 @@ class ReportController extends Controller
             'data_pool' => $dataPool,
             'featured_years' => $this->get('intracto_secret_santa.featured_years')->getFeaturedYears(),
             'google_data_pool' => $googleDataPool,
+            'difference_data_pool' => $differenceDataPool,
         ];
     }
 }

--- a/src/Intracto/SecretSantaBundle/Controller/ReportController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/ReportController.php
@@ -5,7 +5,6 @@ namespace Intracto\SecretSantaBundle\Controller;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Symfony\Component\HttpFoundation\Request;
 
 class ReportController extends Controller
 {

--- a/src/Intracto/SecretSantaBundle/Controller/ReportController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/ReportController.php
@@ -26,11 +26,9 @@ class ReportController extends Controller
                 $differenceDataPool = $comparison->getComparison($currentYear);
             } else {
                 $dataPool = $report->getPoolReport();
-                $differenceDataPool = [];
             }
         } catch (\Exception $e) {
             $dataPool = [];
-            $differenceDataPool = [];
         }
 
         try {
@@ -43,12 +41,17 @@ class ReportController extends Controller
             $googleDataPool = [];
         }
 
-        return [
+        $data =  [
             'current_year' => $currentYear,
             'data_pool' => $dataPool,
             'featured_years' => $this->get('intracto_secret_santa.featured_years')->getFeaturedYears(),
             'google_data_pool' => $googleDataPool,
-            'difference_data_pool' => $differenceDataPool,
         ];
+
+        if(isset($differenceDataPool)) {
+            $data['difference_data_pool'] = $differenceDataPool;
+        }
+
+        return $data;
     }
 }

--- a/src/Intracto/SecretSantaBundle/Query/EntryReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/EntryReportQuery.php
@@ -252,7 +252,7 @@ class EntryReportQuery
         $entryCountSeason1 = $this->countEntries($season1);
         try {
             $entryCountSeason2 = $this->countEntries($season2);
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             return $entryCountSeason1[0]['entryCount'];
         }
 
@@ -269,7 +269,7 @@ class EntryReportQuery
         $confirmedEntryCountSeason1 = $this->countConfirmedEntries($season1);
         try {
             $confirmedEntryCountSeason2 = $this->countConfirmedEntries($season2);
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             return $confirmedEntryCountSeason1[0]['confirmedEntryCount'];
         }
 
@@ -286,7 +286,7 @@ class EntryReportQuery
         $distinctEntryCountSeason1 = $this->countDistinctEntries($season1);
         try {
             $distinctEntryCountSeason2 = $this->countDistinctEntries($season2);
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             return $distinctEntryCountSeason1[0]['distinctEntryCount'];
         }
 
@@ -303,7 +303,7 @@ class EntryReportQuery
         $averageSeason1 = $this->calculateAverageEntriesPerPool($season1);
         try {
             $averageSeason2 = $this->calculateAverageEntriesPerPool($season2);
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             return $averageSeason1;
         }
 

--- a/src/Intracto/SecretSantaBundle/Query/EntryReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/EntryReportQuery.php
@@ -256,7 +256,6 @@ class EntryReportQuery
             return $entryCountSeason1[0]['entryCount'];
         }
 
-
         return $entryCountSeason1[0]['entryCount'] - $entryCountSeason2[0]['entryCount'];
     }
 
@@ -291,7 +290,6 @@ class EntryReportQuery
             return $distinctEntryCountSeason1[0]['distinctEntryCount'];
         }
 
-
         return $distinctEntryCountSeason1[0]['distinctEntryCount'] - $distinctEntryCountSeason2[0]['distinctEntryCount'];
     }
 
@@ -308,7 +306,6 @@ class EntryReportQuery
         } catch(\Exception $e) {
             return $averageSeason1;
         }
-
 
         return $averageSeason1 - $averageSeason2;
     }

--- a/src/Intracto/SecretSantaBundle/Query/EntryReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/EntryReportQuery.php
@@ -82,6 +82,10 @@ class EntryReportQuery
         return $query->execute()->fetchAll();
     }
 
+    /**
+     * @param \DateTime $date
+     * @return mixed
+     */
     public function countDistinctEntriesUntilDate(\DateTime $date)
     {
         $query = $this->dbal->createQueryBuilder()
@@ -236,5 +240,62 @@ class EntryReportQuery
             ->setParameter('lastDay', $date->format('Y-m-d H:i:s'));
 
         return $query->execute()->fetchAll();
+    }
+
+    /**
+     * @param Season $season1
+     * @param Season $season2
+     * @return mixed
+     */
+    public function calculateEntryCountDifferenceBetweenSeasons(Season $season1, Season $season2)
+    {
+        $entryCountSeason1 = $this->countEntries($season1);
+        $entryCountSeason2 = $this->countEntries($season2);
+
+        return $entryCountSeason1[0]['entryCount'] - $entryCountSeason2[0]['entryCount'];
+    }
+
+    /**
+     * @param Season $season1
+     * @param Season $season2
+     * @return mixed
+     */
+    public function calculateConfirmedEntryCountDifferenceBetweenSeasons(Season $season1, Season $season2)
+    {
+        $confirmedEntryCountSeason1 = $this->countConfirmedEntries($season1);
+        $confirmedEntryCountSeason2 = $this->countConfirmedEntries($season2);
+
+        return $confirmedEntryCountSeason1[0]['confirmedEntryCount'] - $confirmedEntryCountSeason2[0]['confirmedEntryCount'];
+    }
+
+    /**
+     * @param Season $season1
+     * @param Season $season2
+     * @return mixed
+     */
+    public function calculateDistinctEntryCountDifferenceBetweenSeasons(Season $season1, Season $season2)
+    {
+        $distinctEntryCountSeason1 = $this->countDistinctEntries($season1);
+        $distinctEntryCountSeason2 = $this->countDistinctEntries($season2);
+
+        return $distinctEntryCountSeason1[0]['distinctEntryCount'] - $distinctEntryCountSeason2[0]['distinctEntryCount'];
+    }
+
+    /**
+     * @param Season $season1
+     * @param Season $season2
+     * @return float
+     */
+    public function calculateAverageEntriesPerPoolBetweenSeasons(Season $season1, Season $season2)
+    {
+        $averageSeason1 = $this->calculateAverageEntriesPerPool($season1);
+        try {
+            $averageSeason2 = $this->calculateAverageEntriesPerPool($season2);
+        } catch(\Exception $e) {
+            $averageSeason2 = 0;
+        }
+
+
+        return $averageSeason1 - $averageSeason2;
     }
 }

--- a/src/Intracto/SecretSantaBundle/Query/EntryReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/EntryReportQuery.php
@@ -250,7 +250,12 @@ class EntryReportQuery
     public function calculateEntryCountDifferenceBetweenSeasons(Season $season1, Season $season2)
     {
         $entryCountSeason1 = $this->countEntries($season1);
-        $entryCountSeason2 = $this->countEntries($season2);
+        try {
+            $entryCountSeason2 = $this->countEntries($season2);
+        } catch(\Exception $e) {
+            return $entryCountSeason1[0]['entryCount'];
+        }
+
 
         return $entryCountSeason1[0]['entryCount'] - $entryCountSeason2[0]['entryCount'];
     }
@@ -263,7 +268,11 @@ class EntryReportQuery
     public function calculateConfirmedEntryCountDifferenceBetweenSeasons(Season $season1, Season $season2)
     {
         $confirmedEntryCountSeason1 = $this->countConfirmedEntries($season1);
-        $confirmedEntryCountSeason2 = $this->countConfirmedEntries($season2);
+        try {
+            $confirmedEntryCountSeason2 = $this->countConfirmedEntries($season2);
+        } catch(\Exception $e) {
+            return $confirmedEntryCountSeason1[0]['confirmedEntryCount'];
+        }
 
         return $confirmedEntryCountSeason1[0]['confirmedEntryCount'] - $confirmedEntryCountSeason2[0]['confirmedEntryCount'];
     }
@@ -276,7 +285,12 @@ class EntryReportQuery
     public function calculateDistinctEntryCountDifferenceBetweenSeasons(Season $season1, Season $season2)
     {
         $distinctEntryCountSeason1 = $this->countDistinctEntries($season1);
-        $distinctEntryCountSeason2 = $this->countDistinctEntries($season2);
+        try {
+            $distinctEntryCountSeason2 = $this->countDistinctEntries($season2);
+        } catch(\Exception $e) {
+            return $distinctEntryCountSeason1[0]['distinctEntryCount'];
+        }
+
 
         return $distinctEntryCountSeason1[0]['distinctEntryCount'] - $distinctEntryCountSeason2[0]['distinctEntryCount'];
     }
@@ -292,7 +306,7 @@ class EntryReportQuery
         try {
             $averageSeason2 = $this->calculateAverageEntriesPerPool($season2);
         } catch(\Exception $e) {
-            $averageSeason2 = 0;
+            return $averageSeason1;
         }
 
 

--- a/src/Intracto/SecretSantaBundle/Query/GoogleAnalyticsQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/GoogleAnalyticsQuery.php
@@ -42,7 +42,7 @@ class GoogleAnalyticsQuery
 
         return [
             'countries' => $this->getTopCountries($gaParameters)->rows,
-            'language' => $this->getTopLanguages($gaParameters)->rows,
+            'language' => $this->getTopLanguages($gaParameters),
             'deviceCategory' => $this->getDeviceCategory($gaParameters)->rows,
             'browser' => $this->getBrowsers($gaParameters)->rows,
         ];
@@ -72,7 +72,7 @@ class GoogleAnalyticsQuery
      */
     public function getTopLanguages(GaParameters $gaParameters)
     {
-        return $gaParameters->getAnalytics()->data_ga->get(
+        $query = $gaParameters->getAnalytics()->data_ga->get(
             $gaParameters->getViewId(),
             $gaParameters->getStart(),
             $gaParameters->getEnd(),
@@ -82,6 +82,257 @@ class GoogleAnalyticsQuery
                 'sort' => '-ga:sessions, -ga:language'
             ]
         );
+
+        $languages = [];
+
+        $english = 0;
+        $spanish = 0;
+        $dutch = 0;
+        $french = 0;
+        $russian = 0;
+        $portuguese = 0;
+        $german = 0;
+        $chinese = 0;
+        $korean = 0;
+        $romanian = 0;
+        $italian = 0;
+        $ukrainian = 0;
+        $swedish = 0;
+        $polish = 0;
+        $japanese = 0;
+        $greek = 0;
+        $turkish = 0;
+        $bulgarian = 0;
+        $vietnamese = 0;
+        $norwegian = 0;
+        $danish = 0;
+        $finnish = 0;
+        $hungarian = 0;
+        $estonian = 0;
+        $lithuanian = 0;
+        $latvian = 0;
+        $serbian = 0;
+        $slovene = 0;
+        $slovak = 0;
+        $croatian = 0;
+        $czech = 0;
+        $arabic = 0;
+        $maltese = 0;
+        $thai = 0;
+        $hebrew = 0;
+        $bosnian = 0;
+        $kazakh = 0;
+        $indonesian = 0;
+        $afrikaans = 0;
+        $malay = 0;
+        $tonga = 0;
+        $georgian = 0;
+        $tagalog = 0;
+        $icelandic = 0;
+        $mongolian = 0;
+        $bihari = 0;
+        $akan = 0;
+        $persian = 0;
+        $maori = 0;
+        $belarusian = 0;
+        $gujarati = 0;
+        $hindi = 0;
+        $luxembourgish = 0;
+        $tamil = 0;
+        $uzbek = 0;
+        $swahili = 0;
+        $panjabi = 0;
+
+        foreach ($query->rows as $lang) {
+            if (strpos($lang[0], 'en') !== false ||
+                strpos($lang[0], 'ga') !== false ||
+                strpos($lang[0], 'cy') !== false
+            ) {
+                $english += $lang[1];
+            } else if (strpos($lang[0], 'es') !== false ||
+                       strpos($lang[0], 'ca') !== false ||
+                       strpos($lang[0], 'gl') !== false ||
+                       strpos($lang[0], 'eu') !== false
+            ) {
+                $spanish += $lang[1];
+            } else if (strpos($lang[0], 'nl') !== false) {
+                $dutch += $lang[1];
+            } else if (strpos($lang[0], 'fr') !== false ||
+                       strpos($lang[0], 'br') !== false
+            ) {
+                $french += $lang[1];
+            } else if (strpos($lang[0], 'ru') !== false) {
+                $russian += $lang[1];
+            } else if (strpos($lang[0], 'pt') !== false) {
+                $portuguese += $lang[1];
+            } else if (strpos($lang[0], 'de') !== false) {
+                $german += $lang[1];
+            } else if (strpos($lang[0], 'zh') !== false) {
+                $chinese += $lang[1];
+            } else if (strpos($lang[0], 'ko') !== false) {
+                $korean += $lang[1];
+            } else if (strpos($lang[0], 'ro') !== false) {
+                $romanian += $lang[1];
+            } else if (strpos($lang[0], 'it') !== false) {
+                $italian += $lang[1];
+            } else if (strpos($lang[0], 'uk') !== false) {
+                $ukrainian += $lang[1];
+            } else if (strpos($lang[0], 'sv') !== false) {
+                $swedish += $lang[1];
+            } else if (strpos($lang[0], 'pl') !== false) {
+                $polish += $lang[1];
+            } else if (strpos($lang[0], 'ja') !== false) {
+                $japanese += $lang[1];
+            } else if (strpos($lang[0], 'el') !== false) {
+                $greek += $lang[1];
+            } else if (strpos($lang[0], 'tr') !== false) {
+                $turkish += $lang[1];
+            } else if (strpos($lang[0], 'bg') !== false) {
+                $bulgarian += $lang[1];
+            } else if (strpos($lang[0], 'vi') !== false) {
+                $vietnamese += $lang[1];
+            } else if (strpos($lang[0], 'nb') !== false ||
+                       strpos($lang[0], 'no') !== false
+            ) {
+                $norwegian += $lang[1];
+            } else if (strpos($lang[0], 'da') !== false) {
+                $danish += $lang[1];
+            } else if (strpos($lang[0], 'fi') !== false) {
+                $finnish += $lang[1];
+            } else if (strpos($lang[0], 'hu') !== false) {
+                $hungarian += $lang[1];
+            } else if (strpos($lang[0], 'et') !== false) {
+                $estonian += $lang[1];
+            } else if (strpos($lang[0], 'lt') !== false) {
+                $lithuanian += $lang[1];
+            } else if (strpos($lang[0], 'lv') !== false) {
+                $latvian += $lang[1];
+            } else if (strpos($lang[0], 'sr') !== false) {
+                $serbian += $lang[1];
+            } else if (strpos($lang[0], 'sl') !== false) {
+                $slovene += $lang[1];
+            } else if (strpos($lang[0], 'sk') !== false) {
+                $slovak += $lang[1];
+            } else if (strpos($lang[0], 'hr') !== false) {
+                $croatian += $lang[1];
+            } else if (strpos($lang[0], 'cs') !== false) {
+                $czech += $lang[1];
+            } else if (strpos($lang[0], 'ar') !== false) {
+                $arabic += $lang[1];
+            } else if (strpos($lang[0], 'mt') !== false) {
+                $maltese += $lang[1];
+            } else if (strpos($lang[0], 'th') !== false) {
+                $thai += $lang[1];
+            } else if (strpos($lang[0], 'he') !== false) {
+                $hebrew += $lang[1];
+            } else if (strpos($lang[0], 'bs') !== false) {
+                $bosnian += $lang[1];
+            } else if (strpos($lang[0], 'kk') !== false) {
+                $kazakh += $lang[1];
+            } else if (strpos($lang[0], 'id') !== false) {
+                $indonesian += $lang[1];
+            } else if (strpos($lang[0], 'af') !== false) {
+                $afrikaans += $lang[1];
+            } else if (strpos($lang[0], 'ms') !== false) {
+                $malay += $lang[1];
+            } else if (strpos($lang[0], 'to') !== false) {
+                $tonga += $lang[1];
+            } else if (strpos($lang[0], 'ka') !== false) {
+                $georgian += $lang[1];
+            } else if (strpos($lang[0], 'tl') !== false) {
+                $tagalog += $lang[1];
+            } else if (strpos($lang[0], 'is') !== false) {
+                $icelandic += $lang[1];
+            } else if (strpos($lang[0], 'mn') !== false) {
+                $mongolian += $lang[1];
+            } else if (strpos($lang[0], 'bh') !== false) {
+                $bihari += $lang[1];
+            } else if (strpos($lang[0], 'ak') !== false) {
+                $akan += $lang[1];
+            } else if (strpos($lang[0], 'fa') !== false) {
+                $persian += $lang[1];
+            } else if (strpos($lang[0], 'mi') !== false) {
+                $maori += $lang[1];
+            } else if (strpos($lang[0], 'be') !== false) {
+                $belarusian += $lang[1];
+            } else if (strpos($lang[0], 'gu') !== false) {
+                $gujarati += $lang[1];
+            } else if (strpos($lang[0], 'hi') !== false) {
+                $hindi += $lang[1];
+            } else if (strpos($lang[0], 'lb') !== false) {
+                $luxembourgish += $lang[1];
+            } else if (strpos($lang[0], 'ta') !== false) {
+                $tamil += $lang[1];
+            } else if (strpos($lang[0], 'uz') !== false) {
+                $uzbek += $lang[1];
+            } else if (strpos($lang[0], 'sw') !== false) {
+                $swahili += $lang[1];
+            } else if (strpos($lang[0], 'pa') !== false) {
+                $panjabi += $lang[1];
+            } else {
+                array_push($languages, [$lang[0], (int) $lang[1]]);
+            }
+        }
+
+        array_push($languages, ['English', $english]);
+        array_push($languages, ['Spanish', $spanish]);
+        array_push($languages, ['Dutch', $dutch]);
+        array_push($languages, ['French', $french]);
+        array_push($languages, ['Russian', $russian]);
+        array_push($languages, ['Portuguese', $portuguese]);
+        array_push($languages, ['German', $german]);
+        array_push($languages, ['Chinese', $chinese]);
+        array_push($languages, ['Korean', $korean]);
+        array_push($languages, ['Romanian', $romanian]);
+        array_push($languages, ['Italian', $italian]);
+        array_push($languages, ['Ukrainian', $ukrainian]);
+        array_push($languages, ['Swedish', $swedish]);
+        array_push($languages, ['Polish', $polish]);
+        array_push($languages, ['Japanese', $japanese]);
+        array_push($languages, ['Greek', $greek]);
+        array_push($languages, ['Turkish', $turkish]);
+        array_push($languages, ['Bulgarian', $bulgarian]);
+        array_push($languages, ['Vietnamese', $vietnamese]);
+        array_push($languages, ['Norwegian', $norwegian]);
+        array_push($languages, ['Danish', $danish]);
+        array_push($languages, ['Finnish', $finnish]);
+        array_push($languages, ['Hungarian', $hungarian]);
+        array_push($languages, ['Estonian', $estonian]);
+        array_push($languages, ['Lithuanian', $lithuanian]);
+        array_push($languages, ['Latvian', $latvian]);
+        array_push($languages, ['Serbian', $serbian]);
+        array_push($languages, ['Slovene', $slovene]);
+        array_push($languages, ['Slovak', $slovak]);
+        array_push($languages, ['Croatian', $croatian]);
+        array_push($languages, ['Czech', $czech]);
+        array_push($languages, ['Arabic', $arabic]);
+        array_push($languages, ['Maltese', $maltese]);
+        array_push($languages, ['Thai', $thai]);
+        array_push($languages, ['Hebrew', $hebrew]);
+        array_push($languages, ['Bosnian', $bosnian]);
+        array_push($languages, ['Kazach', $kazakh]);
+        array_push($languages, ['Indonesian', $indonesian]);
+        array_push($languages, ['Afrikaans', $afrikaans]);
+        array_push($languages, ['Malay', $malay]);
+        array_push($languages, ['Tonga', $tonga]);
+        array_push($languages, ['Georgian', $georgian]);
+        array_push($languages, ['Tagalog', $tagalog]);
+        array_push($languages, ['Icelandic', $icelandic]);
+        array_push($languages, ['Mongolian', $mongolian]);
+        array_push($languages, ['Bihari', $bihari]);
+        array_push($languages, ['Akan', $akan]);
+        array_push($languages, ['Persian', $persian]);
+        array_push($languages, ['Maori', $maori]);
+        array_push($languages, ['Belarusian', $belarusian]);
+        array_push($languages, ['Gujarati', $gujarati]);
+        array_push($languages, ['Hindi', $hindi]);
+        array_push($languages, ['Luxembourgish', $luxembourgish]);
+        array_push($languages, ['Tamil', $tamil]);
+        array_push($languages, ['Uzbek', $uzbek]);
+        array_push($languages, ['Swahili', $swahili]);
+        array_push($languages, ['Panjabi', $panjabi]);
+
+        return $languages;
     }
 
     /**

--- a/src/Intracto/SecretSantaBundle/Query/GoogleAnalyticsQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/GoogleAnalyticsQuery.php
@@ -150,15 +150,15 @@ class GoogleAnalyticsQuery
             ) {
                 $english += $lang[1];
             } else if (strpos($lang[0], 'es') !== false ||
-                       strpos($lang[0], 'ca') !== false ||
-                       strpos($lang[0], 'gl') !== false ||
-                       strpos($lang[0], 'eu') !== false
+                strpos($lang[0], 'ca') !== false ||
+                strpos($lang[0], 'gl') !== false ||
+                strpos($lang[0], 'eu') !== false
             ) {
                 $spanish += $lang[1];
             } else if (strpos($lang[0], 'nl') !== false) {
                 $dutch += $lang[1];
             } else if (strpos($lang[0], 'fr') !== false ||
-                       strpos($lang[0], 'br') !== false
+                strpos($lang[0], 'br') !== false
             ) {
                 $french += $lang[1];
             } else if (strpos($lang[0], 'ru') !== false) {
@@ -192,7 +192,7 @@ class GoogleAnalyticsQuery
             } else if (strpos($lang[0], 'vi') !== false) {
                 $vietnamese += $lang[1];
             } else if (strpos($lang[0], 'nb') !== false ||
-                       strpos($lang[0], 'no') !== false
+                strpos($lang[0], 'no') !== false
             ) {
                 $norwegian += $lang[1];
             } else if (strpos($lang[0], 'da') !== false) {
@@ -270,7 +270,7 @@ class GoogleAnalyticsQuery
             } else if (strpos($lang[0], 'pa') !== false) {
                 $panjabi += $lang[1];
             } else {
-                array_push($languages, [$lang[0], (int) $lang[1]]);
+                array_push($languages, [$lang[0], (int)$lang[1]]);
             }
         }
 

--- a/src/Intracto/SecretSantaBundle/Query/IpReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/IpReportQuery.php
@@ -27,8 +27,7 @@ class IpReportQuery
         $ipv4 = $this->queryIpv4Records($season);
         $ipv6 = $this->queryIpv6Records($season);
 
-        if($ipv4['ipv4Count'] == 0 && $ipv6['ipv6Count'] == 0)
-        {
+        if ($ipv4['ipv4Count'] == 0 && $ipv6['ipv6Count'] == 0) {
             return [];
         }
 

--- a/src/Intracto/SecretSantaBundle/Query/PoolReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/PoolReportQuery.php
@@ -38,6 +38,24 @@ class PoolReportQuery
         return $query->execute()->fetchAll();
     }
 
+    public function compareSeasonsPools($year)
+    {
+        $season1 = new PoolYear($year);
+        $season2 = new PoolYear($year - 1);
+
+        $poolsSeason1 = $this->countPools($season1);
+
+        if($season2) {
+            $poolsSeason2 = $this->countPools($season2);
+            $difference = $poolsSeason1[0]['poolCount'] - $poolsSeason2[0]['poolCount'];
+
+            return $difference;
+        }
+
+        $difference = $poolsSeason1[0]['poolCount'];
+        return $difference;
+    }
+
     /**
      * @param \DateTime $date
      * @return mixed
@@ -126,5 +144,18 @@ class PoolReportQuery
         }
 
         return $totalPoolChartData;
+    }
+
+    /**
+     * @param PoolYear $season1
+     * @param PoolYear $season2
+     * @return mixed
+     */
+    public function calculatePoolCountDifferenceBetweenSeasons(PoolYear $season1, PoolYear $season2)
+    {
+        $poolCountSeason1 = $this->countPools($season1);
+        $poolCountSeason2 = $this->countPools($season2);
+
+        return $poolCountSeason1[0]['poolCount'] - $poolCountSeason2[0]['poolCount'];
     }
 }

--- a/src/Intracto/SecretSantaBundle/Query/PoolReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/PoolReportQuery.php
@@ -138,7 +138,7 @@ class PoolReportQuery
         $poolCountSeason1 = $this->countPools($season1);
         try {
             $poolCountSeason2 = $this->countPools($season2);
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             return $poolCountSeason1[0]['poolCount'];
         }
 

--- a/src/Intracto/SecretSantaBundle/Query/PoolReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/PoolReportQuery.php
@@ -136,7 +136,12 @@ class PoolReportQuery
     public function calculatePoolCountDifferenceBetweenSeasons(Season $season1, Season $season2)
     {
         $poolCountSeason1 = $this->countPools($season1);
-        $poolCountSeason2 = $this->countPools($season2);
+        try {
+            $poolCountSeason2 = $this->countPools($season2);
+        } catch(\Exception $e) {
+            return $poolCountSeason1[0]['poolCount'];
+        }
+
 
         return $poolCountSeason1[0]['poolCount'] - $poolCountSeason2[0]['poolCount'];
     }

--- a/src/Intracto/SecretSantaBundle/Query/PoolReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/PoolReportQuery.php
@@ -142,7 +142,6 @@ class PoolReportQuery
             return $poolCountSeason1[0]['poolCount'];
         }
 
-
         return $poolCountSeason1[0]['poolCount'] - $poolCountSeason2[0]['poolCount'];
     }
 }

--- a/src/Intracto/SecretSantaBundle/Query/PoolReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/PoolReportQuery.php
@@ -38,24 +38,6 @@ class PoolReportQuery
         return $query->execute()->fetchAll();
     }
 
-    public function compareSeasonsPools($year)
-    {
-        $season1 = new PoolYear($year);
-        $season2 = new PoolYear($year - 1);
-
-        $poolsSeason1 = $this->countPools($season1);
-
-        if($season2) {
-            $poolsSeason2 = $this->countPools($season2);
-            $difference = $poolsSeason1[0]['poolCount'] - $poolsSeason2[0]['poolCount'];
-
-            return $difference;
-        }
-
-        $difference = $poolsSeason1[0]['poolCount'];
-        return $difference;
-    }
-
     /**
      * @param \DateTime $date
      * @return mixed
@@ -147,11 +129,11 @@ class PoolReportQuery
     }
 
     /**
-     * @param PoolYear $season1
-     * @param PoolYear $season2
+     * @param Season $season1
+     * @param Season $season2
      * @return mixed
      */
-    public function calculatePoolCountDifferenceBetweenSeasons(PoolYear $season1, PoolYear $season2)
+    public function calculatePoolCountDifferenceBetweenSeasons(Season $season1, Season $season2)
     {
         $poolCountSeason1 = $this->countPools($season1);
         $poolCountSeason2 = $this->countPools($season2);

--- a/src/Intracto/SecretSantaBundle/Query/SeasonComparisonReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/SeasonComparisonReportQuery.php
@@ -42,16 +42,16 @@ class SeasonComparisonReportQuery
      */
     public function getComparison($year)
     {
-        $season1 = new PoolYear($year);
-        $season2 = new PoolYear($year - 1);
+        $season1 = new Season($year);
+        $season2 = new Season($year - 1);
 
         return [
             'pool_count_difference' => $this->poolReportQuery->calculatePoolCountDifferenceBetweenSeasons($season1, $season2),
             'entry_count_difference' => $this->entryReportQuery->calculateEntryCountDifferenceBetweenSeasons($season1, $season2),
             'confirmed_entry_count_difference' => $this->entryReportQuery->calculateConfirmedEntryCountDifferenceBetweenSeasons($season1, $season2),
             'distinct_entry_count_difference' => $this->entryReportQuery->calculateDistinctEntryCountDifferenceBetweenSeasons($season1, $season2),
-            //'distinct_entries' => $this->entryReportQuery->checkReturningEntriesBetweenSeasons($season1, $season2),
             'average_entries_difference' => $this->entryReportQuery->calculateAverageEntriesPerPoolBetweenSeasons($season1, $season2),
+            'average_wishlist_difference' => $this->wishlistReportQuery->calculateCompletedWishlistDifferenceBetweenSeasons($season1, $season2),
         ];
     }
 }

--- a/src/Intracto/SecretSantaBundle/Query/SeasonComparisonReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/SeasonComparisonReportQuery.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Intracto\SecretSantaBundle\Query;
+
+class SeasonComparisonReportQuery
+{
+    /** @var PoolReportQuery */
+    private $poolReportQuery;
+    /** @var EntryReportQuery */
+    private $entryReportQuery;
+    /** @var IpReportQuery */
+    private $ipReportQuery;
+    /** @var WishlistReportQuery */
+    private $wishlistReportQuery;
+    /** @var FeaturedYearsQuery */
+    private $featuredYearsQuery;
+
+    /**
+     * @param PoolReportQuery $poolReportQuery
+     * @param EntryReportQuery $entryReportQuery
+     * @param IpReportQuery $ipReportQuery
+     * @param WishlistReportQuery $wishlistReportQuery
+     * @param FeaturedYearsQuery $featuredYearsQuery
+     */
+    public function __construct(
+        PoolReportQuery $poolReportQuery,
+        EntryReportQuery $entryReportQuery,
+        IpReportQuery $ipReportQuery,
+        WishlistReportQuery $wishlistReportQuery,
+        FeaturedYearsQuery $featuredYearsQuery
+    ) {
+        $this->poolReportQuery = $poolReportQuery;
+        $this->entryReportQuery = $entryReportQuery;
+        $this->ipReportQuery = $ipReportQuery;
+        $this->wishlistReportQuery = $wishlistReportQuery;
+        $this->featuredYearsQuery = $featuredYearsQuery;
+    }
+
+    /**
+     * @param $year
+     * @return array
+     */
+    public function getComparison($year)
+    {
+        $season1 = new PoolYear($year);
+        $season2 = new PoolYear($year - 1);
+
+        return [
+            'pool_count_difference' => $this->poolReportQuery->calculatePoolCountDifferenceBetweenSeasons($season1, $season2),
+            'entry_count_difference' => $this->entryReportQuery->calculateEntryCountDifferenceBetweenSeasons($season1, $season2),
+            'confirmed_entry_count_difference' => $this->entryReportQuery->calculateConfirmedEntryCountDifferenceBetweenSeasons($season1, $season2),
+            'distinct_entry_count_difference' => $this->entryReportQuery->calculateDistinctEntryCountDifferenceBetweenSeasons($season1, $season2),
+            //'distinct_entries' => $this->entryReportQuery->checkReturningEntriesBetweenSeasons($season1, $season2),
+            'average_entries_difference' => $this->entryReportQuery->calculateAverageEntriesPerPoolBetweenSeasons($season1, $season2),
+        ];
+    }
+}

--- a/src/Intracto/SecretSantaBundle/Query/SeasonComparisonReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/SeasonComparisonReportQuery.php
@@ -8,32 +8,22 @@ class SeasonComparisonReportQuery
     private $poolReportQuery;
     /** @var EntryReportQuery */
     private $entryReportQuery;
-    /** @var IpReportQuery */
-    private $ipReportQuery;
     /** @var WishlistReportQuery */
     private $wishlistReportQuery;
-    /** @var FeaturedYearsQuery */
-    private $featuredYearsQuery;
 
     /**
      * @param PoolReportQuery $poolReportQuery
      * @param EntryReportQuery $entryReportQuery
-     * @param IpReportQuery $ipReportQuery
      * @param WishlistReportQuery $wishlistReportQuery
-     * @param FeaturedYearsQuery $featuredYearsQuery
      */
     public function __construct(
         PoolReportQuery $poolReportQuery,
         EntryReportQuery $entryReportQuery,
-        IpReportQuery $ipReportQuery,
-        WishlistReportQuery $wishlistReportQuery,
-        FeaturedYearsQuery $featuredYearsQuery
+        WishlistReportQuery $wishlistReportQuery
     ) {
         $this->poolReportQuery = $poolReportQuery;
         $this->entryReportQuery = $entryReportQuery;
-        $this->ipReportQuery = $ipReportQuery;
         $this->wishlistReportQuery = $wishlistReportQuery;
-        $this->featuredYearsQuery = $featuredYearsQuery;
     }
 
     /**

--- a/src/Intracto/SecretSantaBundle/Query/WishlistReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/WishlistReportQuery.php
@@ -97,7 +97,11 @@ class WishlistReportQuery
     public function calculateCompletedWishlistDifferenceBetweenSeasons(Season $season1, Season $season2)
     {
         $completedWishlistsSeason1 = $this->calculateCompletedWishlists($season1);
-        $completedWishlistsSeason2 = $this->calculateCompletedWishlists($season2);
+        try {
+            $completedWishlistsSeason2 = $this->calculateCompletedWishlists($season2);
+        } catch(\Exception $e) {
+            return $completedWishlistsSeason1;
+        }
 
         return $completedWishlistsSeason1 - $completedWishlistsSeason2;
     }

--- a/src/Intracto/SecretSantaBundle/Query/WishlistReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/WishlistReportQuery.php
@@ -99,7 +99,7 @@ class WishlistReportQuery
         $completedWishlistsSeason1 = $this->calculateCompletedWishlists($season1);
         try {
             $completedWishlistsSeason2 = $this->calculateCompletedWishlists($season2);
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             return $completedWishlistsSeason1;
         }
 

--- a/src/Intracto/SecretSantaBundle/Query/WishlistReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/WishlistReportQuery.php
@@ -88,4 +88,17 @@ class WishlistReportQuery
 
         return $query->execute()->fetchAll();
     }
+
+    /**
+     * @param Season $season1
+     * @param Season $season2
+     * @return float
+     */
+    public function calculateCompletedWishlistDifferenceBetweenSeasons(Season $season1, Season $season2)
+    {
+        $completedWishlistsSeason1 = $this->calculateCompletedWishlists($season1);
+        $completedWishlistsSeason2 = $this->calculateCompletedWishlists($season2);
+
+        return $completedWishlistsSeason1 - $completedWishlistsSeason2;
+    }
 }

--- a/src/Intracto/SecretSantaBundle/Resources/config/services.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/services.xml
@@ -34,5 +34,12 @@
             <argument>%ga_view_id%</argument>
             <argument>%kernel.root_dir%/config/client_secrets.json</argument>
         </service>
+        <service id="intracto_secret_santa.season_comparison" class="Intracto\SecretSantaBundle\Query\SeasonComparisonReportQuery">
+            <argument type="service" id="intracto_secret_santa.pool"></argument>
+            <argument type="service" id="intracto_secret_santa.entry"></argument>
+            <argument type="service" id="intracto_secret_santa.ip"></argument>
+            <argument type="service" id="intracto_secret_santa.wishlist"></argument>
+            <argument type="service" id="intracto_secret_santa.featured_years"></argument>
+        </service>
     </services>
 </container>

--- a/src/Intracto/SecretSantaBundle/Resources/config/services.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/services.xml
@@ -37,9 +37,7 @@
         <service id="intracto_secret_santa.season_comparison" class="Intracto\SecretSantaBundle\Query\SeasonComparisonReportQuery">
             <argument type="service" id="intracto_secret_santa.pool"></argument>
             <argument type="service" id="intracto_secret_santa.entry"></argument>
-            <argument type="service" id="intracto_secret_santa.ip"></argument>
             <argument type="service" id="intracto_secret_santa.wishlist"></argument>
-            <argument type="service" id="intracto_secret_santa.featured_years"></argument>
         </service>
     </services>
 </container>

--- a/src/Intracto/SecretSantaBundle/Resources/public/css/report.css
+++ b/src/Intracto/SecretSantaBundle/Resources/public/css/report.css
@@ -44,3 +44,11 @@
 .report_inside table tr td:nth-child(2) {
     font-weight: bold;
 }
+
+.positive {
+    color: green;
+}
+
+.negative {
+    color: red;
+}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Report/report.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Report/report.html.twig
@@ -43,7 +43,7 @@
                 {% endif %}
 
                 <table>
-                    <col width="60%">
+                    <col width="55%">
                     <col width="20%">
                     <tr>
                         <td>{{ 'report.confirmed_parties'|trans }}:</td>
@@ -51,6 +51,8 @@
                         {% if difference_data_pool is not empty %}
                             {% if difference_data_pool['pool_count_difference'] > 0 %}
                                 <td class="positive">+ {{ difference_data_pool['pool_count_difference'] }}</td>
+                            {% elseif difference_data_pool['pool_count_difference'] == 0 %}
+                                <td>0</td>
                             {% else %}
                                 <td class="negative">- {{ difference_data_pool['pool_count_difference'] }}</td>
                             {% endif %}
@@ -62,6 +64,8 @@
                         {% if difference_data_pool is not empty %}
                             {% if difference_data_pool['entry_count_difference'] > 0 %}
                                 <td class="positive">+ {{ difference_data_pool['entry_count_difference'] }}</td>
+                            {% elseif difference_data_pool['entry_count_difference'] == 0 %}
+                                <td>0</td>
                             {% else %}
                                 <td class="negative">- {{ difference_data_pool['entry_count_difference'] }}</td>
                             {% endif %}
@@ -73,6 +77,8 @@
                         {% if difference_data_pool is not empty %}
                             {% if difference_data_pool['confirmed_entry_count_difference'] > 0 %}
                                 <td class="positive">+ {{ difference_data_pool['confirmed_entry_count_difference'] }}</td>
+                            {% elseif difference_data_pool['confirmed_entry_count_difference'] == 0 %}
+                                <td>0</td>
                             {% else %}
                                 <td class="negative">- {{ difference_data_pool['confirmed_entry_count_difference'] }}</td>
                             {% endif %}
@@ -97,6 +103,8 @@
                         {% if difference_data_pool is not empty %}
                             {% if difference_data_pool['distinct_entry_count_difference'] > 0 %}
                                 <td class="positive">+ {{ difference_data_pool['distinct_entry_count_difference'] }}</td>
+                            {% elseif difference_data_pool['distinct_entry_count_difference'] == 0 %}
+                                <td>0</td>
                             {% else %}
                                 <td class="negative">- {{ difference_data_pool['distinct_entry_count_difference'] }}</td>
                             {% endif %}
@@ -105,6 +113,15 @@
                     <tr>
                         <td>{{ 'report.completed_wishlists'|trans }}:</td>
                         <td>{{ data_pool['wishlist_average']|number_format(2, '.', '') }} %</td>
+                        {% if difference_data_pool is not empty %}
+                            {% if difference_data_pool['average_wishlist_difference']|number_format(2, '.', '') > 0 %}
+                                <td class="positive">+ {{ difference_data_pool['average_wishlist_difference']|number_format(2, '.', '') }} %</td>
+                            {% elseif difference_data_pool['average_wishlist_difference']|number_format(2, '.', '') == 0 %}
+                                <td>0.00%</td>
+                            {% else %}
+                                <td class="negative">- {{ difference_data_pool['average_wishlist_difference']|number_format(2, '.', '') }} %</td>
+                            {% endif %}
+                        {% endif %}
                     </tr>
                 </table>
             </div>
@@ -116,10 +133,9 @@
             <div class="col-xs-12 col-md-6 report">
                 <div class="report_inside">
                     <h3>{{ 'report.total'|trans }}</h3>
-
                     <table>
-                        <col width="60%">
-                        <col width="40%">
+                        <col width="55%">
+                        <col width="45%">
                         <tr>
                             <td>{{ 'report.confirmed_parties'|trans }}:</td>
                             <td>{{ data_pool['total_pools'][0]['poolCount'] }}</td>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Report/report.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Report/report.html.twig
@@ -43,8 +43,9 @@
                 {% endif %}
 
                 <table>
-                    <col width="55%">
-                    <col width="20%">
+                    <col width="50%">
+                    <col width="25%">
+                    <col width="25%">
                     <tr>
                         <td>{{ 'report.confirmed_parties'|trans }}:</td>
                         <td>{{ data_pool['pools'][0]['poolCount'] }}</td>
@@ -134,8 +135,8 @@
                 <div class="report_inside">
                     <h3>{{ 'report.total'|trans }}</h3>
                     <table>
-                        <col width="55%">
-                        <col width="45%">
+                        <col width="50%">
+                        <col width="50%">
                         <tr>
                             <td>{{ 'report.confirmed_parties'|trans }}:</td>
                             <td>{{ data_pool['total_pools'][0]['poolCount'] }}</td>
@@ -270,6 +271,7 @@
 
             function drawChart() {
                 var chartOptions = {
+                    height: 300,
                     legend: {position: 'bottom'},
                     colors: [
                         '#c41425',
@@ -291,6 +293,9 @@
                 };
 
                 var analyticsChartOptions = {
+                    height: 300,
+                    chartArea: { left: 0, right:0 },
+                    legend: { alignment: 'center' },
                     backgroundColor: { fill:'transparent' }
                 }
 

--- a/src/Intracto/SecretSantaBundle/Resources/views/Report/report.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Report/report.html.twig
@@ -9,20 +9,18 @@
 {% endblock stylesheets %}
 {% block main %}
     <h1>{{ 'report.title'|trans }}</h1>
-    <form method="GET">
-        <div class="row">
-            <div class="col-xs-12 col-md-3">
-                <select name="year" id="Year" class="form-control" onchange="this.form.submit();">
-                    <option {% if(current_year == "all") %} selected="selected" {% endif %}
-                            value="all">{{ 'report.all_time'|trans }}</option>
-                    {% for year in featured_years['featured_years'] %}
-                        <option value="{{ year }}" {% if(current_year == year) %} selected="selected" {% endif %}>{{ year }}
-                            - {{ year+1 }} </option>
-                    {% endfor %}
-                </select>
-            </div>
+    <div class="row">
+        <div class="col-xs-12 col-md-3">
+            <select name="year" id="select-season" class="form-control"">
+                <option {% if(current_year == "all") %} selected="selected" {% endif %}
+                        value="all">{{ 'report.all_time'|trans }}</option>
+                {% for year in featured_years['featured_years'] %}
+                    <option value="{{ year }}" {% if(current_year == year) %} selected="selected" {% endif %}>{{ year }}
+                        - {{ year+1 }} </option>
+                {% endfor %}
+            </select>
         </div>
-    </form>
+    </div>
     <small>{{ 'report.season_info'|trans }}</small>
     {% if data_pool is empty %}
         <div>
@@ -261,6 +259,11 @@
         <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
         <script type="text/javascript">
             $(document).ready(function(){
+                $('#select-season').on('change', function() {
+                    var url = '{{ path("report", { 'year' : "CHOICE" }) }}';
+                    window.location = url.replace('CHOICE', $(this).val());
+                });
+
                 $(window).resize(function(){
                     drawChart();
                 });

--- a/src/Intracto/SecretSantaBundle/Resources/views/Report/report.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Report/report.html.twig
@@ -48,7 +48,7 @@
                     <tr>
                         <td>{{ 'report.confirmed_parties'|trans }}:</td>
                         <td>{{ data_pool['pools'][0]['poolCount'] }}</td>
-                        {% if difference_data_pool is not empty %}
+                        {% if difference_data_pool is defined and difference_data_pool is not empty %}
                             {% if difference_data_pool['pool_count_difference'] > 0 %}
                                 <td class="positive">+ {{ difference_data_pool['pool_count_difference'] }}</td>
                             {% elseif difference_data_pool['pool_count_difference'] == 0 %}
@@ -61,7 +61,7 @@
                     <tr>
                         <td>{{ 'report.invited_participants'|trans }}:</td>
                         <td>{{ data_pool['entries'][0]['entryCount'] }}</td>
-                        {% if difference_data_pool is not empty %}
+                        {% if difference_data_pool is defined and difference_data_pool is not empty %}
                             {% if difference_data_pool['entry_count_difference'] > 0 %}
                                 <td class="positive">+ {{ difference_data_pool['entry_count_difference'] }}</td>
                             {% elseif difference_data_pool['entry_count_difference'] == 0 %}
@@ -74,7 +74,7 @@
                     <tr>
                         <td>{{ 'report.confirmed_participants'|trans }}:</td>
                         <td>{{ data_pool['confirmed_entries'][0]['confirmedEntryCount'] }}</td>
-                        {% if difference_data_pool is not empty %}
+                        {% if difference_data_pool is defined and difference_data_pool is not empty %}
                             {% if difference_data_pool['confirmed_entry_count_difference'] > 0 %}
                                 <td class="positive">+ {{ difference_data_pool['confirmed_entry_count_difference'] }}</td>
                             {% elseif difference_data_pool['confirmed_entry_count_difference'] == 0 %}
@@ -87,7 +87,7 @@
                     <tr>
                         <td>{{ 'report.average_entries'|trans }}:</td>
                         <td>{{ data_pool['entry_average']|round }}</td>
-                        {% if difference_data_pool is not empty %}
+                        {% if difference_data_pool is defined and difference_data_pool is not empty %}
                             {% if difference_data_pool['average_entries_difference']|round > 0 %}
                                 <td class="positive">+ {{ difference_data_pool['average_entries_difference']|round }}</td>
                             {% elseif difference_data_pool['average_entries_difference']|round == 0 %}
@@ -100,7 +100,7 @@
                     <tr>
                         <td>{{ 'report.unique_entries'|trans }}:</td>
                         <td>{{ data_pool['distinct_entries'][0]['distinctEntryCount'] }}</td>
-                        {% if difference_data_pool is not empty %}
+                        {% if difference_data_pool is defined and difference_data_pool is not empty %}
                             {% if difference_data_pool['distinct_entry_count_difference'] > 0 %}
                                 <td class="positive">+ {{ difference_data_pool['distinct_entry_count_difference'] }}</td>
                             {% elseif difference_data_pool['distinct_entry_count_difference'] == 0 %}
@@ -113,7 +113,7 @@
                     <tr>
                         <td>{{ 'report.completed_wishlists'|trans }}:</td>
                         <td>{{ data_pool['wishlist_average']|number_format(2, '.', '') }} %</td>
-                        {% if difference_data_pool is not empty %}
+                        {% if difference_data_pool is defined and difference_data_pool is not empty %}
                             {% if difference_data_pool['average_wishlist_difference']|number_format(2, '.', '') > 0 %}
                                 <td class="positive">+ {{ difference_data_pool['average_wishlist_difference']|number_format(2, '.', '') }} %</td>
                             {% elseif difference_data_pool['average_wishlist_difference']|number_format(2, '.', '') == 0 %}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Report/report.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Report/report.html.twig
@@ -43,25 +43,64 @@
                 {% endif %}
 
                 <table>
+                    <col width="60%">
+                    <col width="20%">
                     <tr>
                         <td>{{ 'report.confirmed_parties'|trans }}:</td>
                         <td>{{ data_pool['pools'][0]['poolCount'] }}</td>
+                        {% if difference_data_pool is not empty %}
+                            {% if difference_data_pool['pool_count_difference'] > 0 %}
+                                <td class="positive">+ {{ difference_data_pool['pool_count_difference'] }}</td>
+                            {% else %}
+                                <td class="negative">- {{ difference_data_pool['pool_count_difference'] }}</td>
+                            {% endif %}
+                        {% endif %}
                     </tr>
                     <tr>
                         <td>{{ 'report.invited_participants'|trans }}:</td>
                         <td>{{ data_pool['entries'][0]['entryCount'] }}</td>
+                        {% if difference_data_pool is not empty %}
+                            {% if difference_data_pool['entry_count_difference'] > 0 %}
+                                <td class="positive">+ {{ difference_data_pool['entry_count_difference'] }}</td>
+                            {% else %}
+                                <td class="negative">- {{ difference_data_pool['entry_count_difference'] }}</td>
+                            {% endif %}
+                        {% endif %}
                     </tr>
                     <tr>
                         <td>{{ 'report.confirmed_participants'|trans }}:</td>
                         <td>{{ data_pool['confirmed_entries'][0]['confirmedEntryCount'] }}</td>
+                        {% if difference_data_pool is not empty %}
+                            {% if difference_data_pool['confirmed_entry_count_difference'] > 0 %}
+                                <td class="positive">+ {{ difference_data_pool['confirmed_entry_count_difference'] }}</td>
+                            {% else %}
+                                <td class="negative">- {{ difference_data_pool['confirmed_entry_count_difference'] }}</td>
+                            {% endif %}
+                        {% endif %}
                     </tr>
                     <tr>
                         <td>{{ 'report.average_entries'|trans }}:</td>
                         <td>{{ data_pool['entry_average']|round }}</td>
+                        {% if difference_data_pool is not empty %}
+                            {% if difference_data_pool['average_entries_difference']|round > 0 %}
+                                <td class="positive">+ {{ difference_data_pool['average_entries_difference']|round }}</td>
+                            {% elseif difference_data_pool['average_entries_difference']|round == 0 %}
+                                <td>0</td>
+                            {% else %}
+                                <td class="negative">- {{ difference_data_pool['average_entries_difference']|round }}</td>
+                            {% endif %}
+                        {% endif %}
                     </tr>
                     <tr>
                         <td>{{ 'report.unique_entries'|trans }}:</td>
                         <td>{{ data_pool['distinct_entries'][0]['distinctEntryCount'] }}</td>
+                        {% if difference_data_pool is not empty %}
+                            {% if difference_data_pool['distinct_entry_count_difference'] > 0 %}
+                                <td class="positive">+ {{ difference_data_pool['distinct_entry_count_difference'] }}</td>
+                            {% else %}
+                                <td class="negative">- {{ difference_data_pool['distinct_entry_count_difference'] }}</td>
+                            {% endif %}
+                        {% endif %}
                     </tr>
                     <tr>
                         <td>{{ 'report.completed_wishlists'|trans }}:</td>
@@ -79,6 +118,8 @@
                     <h3>{{ 'report.total'|trans }}</h3>
 
                     <table>
+                        <col width="60%">
+                        <col width="40%">
                         <tr>
                             <td>{{ 'report.confirmed_parties'|trans }}:</td>
                             <td>{{ data_pool['total_pools'][0]['poolCount'] }}</td>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Report/report.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Report/report.html.twig
@@ -290,6 +290,10 @@
                     backgroundColor: { fill:'transparent' }
                 };
 
+                var analyticsChartOptions = {
+                    backgroundColor: { fill:'transparent' }
+                }
+
                 {% if current_year != 'all' %}
                     var poolData = new google.visualization.DataTable();
                     poolData.addColumn('string', 'Month');
@@ -371,7 +375,7 @@
                     ]);
 
                     var ipChart = new google.visualization.PieChart(document.getElementById('ip_chart'));
-                    ipChart.draw(ipData, chartOptions);
+                    ipChart.draw(ipData, analyticsChartOptions);
                 {% endif %}
 
                 var countryData = new google.visualization.DataTable();
@@ -383,7 +387,7 @@
                     {% endfor %}
                 ]);
                 var countryChart = new google.visualization.PieChart(document.getElementById('country_chart'));
-                countryChart.draw(countryData, chartOptions);
+                countryChart.draw(countryData, analyticsChartOptions);
 
                 var languageData = new google.visualization.DataTable();
                 languageData.addColumn('string', 'Language');
@@ -394,7 +398,7 @@
                     {% endfor %}
                 ]);
                 var languageChart = new google.visualization.PieChart(document.getElementById('language_chart'));
-                languageChart.draw(languageData, chartOptions);
+                languageChart.draw(languageData, analyticsChartOptions);
 
                 var deviceData = new google.visualization.DataTable();
                 deviceData.addColumn('string', 'Device');
@@ -405,7 +409,7 @@
                     {% endfor %}
                 ]);
                 var deviceChart = new google.visualization.PieChart(document.getElementById('device_chart'));
-                deviceChart.draw(deviceData, chartOptions);
+                deviceChart.draw(deviceData, analyticsChartOptions);
 
                 var browserData = new google.visualization.DataTable();
                 browserData.addColumn('string', 'Device');
@@ -416,7 +420,7 @@
                     {% endfor %}
                 ]);
                 var browserChart = new google.visualization.PieChart(document.getElementById('browser_chart'));
-                browserChart.draw(browserData, chartOptions);
+                browserChart.draw(browserData, analyticsChartOptions);
             }
         </script>
     {% endif %}


### PR DESCRIPTION
Subissue of #61 

Each season shows how much the number has increased or decreased compared to the previous season.

Google Analytics charts now have their legend on the right side and are enlarged for easier reading. The language codes that belong to the same main language have been put together in a category so that we get a better overview. This might still need some refining. Now there are many categories and maybe of same of them can be merged together, not sure about that. The array with all the language categories might need to be sorted by amount of people, but the sorting did not work out.