### PR TITLE
Pool update for participants

### DIFF
--- a/src/Intracto/SecretSantaBundle/Controller/PoolController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/PoolController.php
@@ -296,6 +296,29 @@ class PoolController extends Controller
     }
 
     /**
+     * @Route("/pool-update/{listUrl}", name="pool_update")
+     * @Template()
+     */
+    public function sendPoolUpdateAction($listUrl)
+    {
+        $entryQuery = $this->get('intracto_secret_santa.entry');
+        $mailService = $this->get('intracto_secret_santa.mail');
+
+        $results = $entryQuery->fetchDataForPoolUpdateMail($listUrl);
+        $this->getPool($listUrl);
+
+        $mailService->sendPoolUpdateMailForPool($this->pool, $results);
+
+        $translator = $this->get('translator');
+        $this->get('session')->getFlashBag()->add(
+            'success',
+            $translator->trans('flashes.pool_update.success')
+        );
+
+        return $this->redirect($this->generateUrl('pool_manage', ['listUrl' => $this->pool->getListurl()]));
+    }
+
+    /**
      * Retrieve pool by url
      *
      * @param $listurl

--- a/src/Intracto/SecretSantaBundle/Mailer/MailerService.php
+++ b/src/Intracto/SecretSantaBundle/Mailer/MailerService.php
@@ -221,4 +221,49 @@ class MailerService
             )
         );
     }
+
+    /**
+     * @param Pool $pool
+     * @param $results
+     */
+    public function sendPoolUpdateMailForPool(Pool $pool, $results)
+    {
+        foreach($pool->getEntries() as $entry) {
+            $this->sendPoolUpdateMailForEntry($entry, $results);
+        }
+    }
+
+    /**
+     * @param Entry $entry
+     * @param $results
+     */
+    public function sendPoolUpdateMailForEntry(Entry $entry, $results)
+    {
+        $this->translator->setLocale($entry->getPool()->getLocale());
+        $this->mailer->send(\Swift_Message::newInstance()
+            ->setSubject($this->translator->trans('emails.pool_update.subject'))
+            ->setFrom($this->adminEmail, $this->translator->trans('emails.sender'))
+            ->setTo($entry->getEmail(), $entry->getName())
+            ->setBody(
+                $this->templating->render(
+                    'IntractoSecretSantaBundle:Emails:poolupdate.html.twig',
+                    [
+                        'entry' => $entry,
+                        'results' => $results,
+                    ]
+                ),
+                'text/html'
+            )
+            ->addPart(
+                $this->templating->render(
+                    'IntractoSecretSantaBundle:Emails:poolupdate.txt.twig',
+                    [
+                        'entry' => $entry,
+                        'results' => $results,
+                    ]
+                ),
+                'text/plain'
+            )
+        );
+    }
 }

--- a/src/Intracto/SecretSantaBundle/Query/EntryReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/EntryReportQuery.php
@@ -365,4 +365,45 @@ class EntryReportQuery
             ]
         );
     }
+
+    /**
+     * @param $listUrl
+     * @return array
+     */
+    public function fetchDataForPoolUpdateMail($listUrl)
+    {
+        $pool = $this->dbal->createQueryBuilder()
+            ->select('p.*, e.name AS adminName')
+            ->from('Pool', 'p')
+            ->innerJoin('p', 'Entry', 'e', 'p.id = e.poolId')
+            ->where('p.listurl = :listurl')
+            ->andWhere('e.poolAdmin = 1')
+            ->setParameter(':listurl', $listUrl);
+        $participantCount = $this->dbal->createQueryBuilder()
+            ->select('count(e.id) AS participantCount')
+            ->from('Pool', 'p')
+            ->innerJoin('p', 'Entry', 'e', 'p.id = e.poolId')
+            ->where('p.listurl = :listurl')
+            ->setParameter(':listurl', $listUrl);
+        $wishlistCount = $this->dbal->createQueryBuilder()
+            ->select('count(e.id) AS wishlistCount')
+            ->from('Pool', 'p')
+            ->innerJoin('p', 'Entry', 'e', 'p.id = e.poolId')
+            ->where('p.listurl = :listurl')
+            ->andWhere('wishlist_updated = 1')
+            ->setParameter(':listurl', $listUrl);
+        $viewedCount = $this->dbal->createQueryBuilder()
+            ->select('count(e.id) AS viewedCount')
+            ->from('Pool', 'p')
+            ->innerJoin('p', 'Entry', 'e', 'p.id = e.poolid')
+            ->where('p.listurl = :listurl')
+            ->andWhere('viewdate is not null')
+            ->setParameter(':listurl', $listUrl);
+        return [
+            'pool' => $pool->execute()->fetchAll(),
+            'participantCount' => $participantCount->execute()->fetchAll(),
+            'wishlistCount' => $wishlistCount->execute()->fetchAll(),
+            'viewedCount' => $viewedCount->execute()->fetchAll(),
+        ];
+    }
 }

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -369,24 +369,24 @@ emails:
 
                 Click the link below and add some stuff to your wishlist you'd like.
     pool_update:
-        subject: Our Secret Santa party
+        subject: Our Secret Santa party is coming soon!
         message:
             html: >
                 Dear %name%, <br/>
                 <br/>
-                You've been invited to %owner%'s party. This party is coming soon and that's why we're bringing you a quick update on what to expect.<br/>
+                We hope you're getting excited for %owner%'s party that's coming up soon. %owner% is expecting %participantCount% people at this party on %date% at/in %place% to enjoy the joy of giving gifts.<br/>
                 <br/>
-                Your party takes place %date% in/at %place%. %owner% has invited %participantCount% people and so far %viewedCount% opened the invitation, %wishlistCount% of them added items to their wishlist.<br/>
+                To achieve maximum pleasure, it would be great if every invitee were to attend this party and brought along a present. So far %viewedCount% people opened their invitation and %wishlistCount% of them made a wishlist.<br/>
                 <br/>
-                If you haven't confirmed your participation or if you haven't filled in your wishlist, click the link down below and contribute to a great party!
+                Be sure to check on your buddy by clicking the link below and make them swing into action if needed. The more the merrier!
             txt: >
                 Dear %name%,
 
-                You've been invited to %owner%'s party. This party is coming soon and that's why we're bringing you a quick update on what to expect.
+                We hope you're getting excited for %owner%'s party that's coming up soon. %owner% is expecting %participantCount% people at this party on %date% at/in %place% to enjoy the joy of giving gifts.
 
-                Your party takes place %date% in/at %place%. %owner% has invited %participantCount% people and so far %viewedCount% opened the invitation, %wishlistCount% of them added items to their wishlist.
+                To achieve maximum pleasure, it would be great if every invitee were to attend this party and brought along a present. So far %viewedCount% people opened their invitation and %wishlistCount% of them made a wishlist.
 
-                If you haven't confirmed your participation or if you haven't filled in your wishlist, click the link down below and contribute to a great party!
+                Be sure to check on your buddy by clicking the link below and make them swing into action if needed. The more the merrier!
         btn_pool_update: Check your buddy and wishlist
     forgot_link:
         text: 'Hi there, <br /><br />You have requested us to resend your activation mail with the event manage link(s)<br />'

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -354,19 +354,24 @@ emails:
                 Following is an overview of which members are supposed to get gifts for which users.
     poke_buddy:
         subject: Your buddy is waiting for your wishlist
+    pool_update:
+        subject: Our Secret Santa party
         message:
             html: >
                 Dear %name%, <br/>
                 <br/>
-                Your Secret Santa buddy is waiting for you to add some items to your wishlist.<br/>
+                You've been invited to %owner%'s party. This party is coming soon and that's why we're bringing you a quick update on what to expect.<br/>
                 <br/>
-                Click the link below and add some stuff to your wishlist you'd like.
+                Your party takes place %date% in/at %place%. %owner% has invited %participantCount% people and so far %viewedCount% opened the invitation, %wishlistCount% of them added items to their wishlist.<br/>
+                <br/>
+                If you haven't confirmed your participation or if you haven't filled in your wishlist, click the link down below and contribute to a great party!
             txt: >
                 Dear %name%,
 
-                Your Secret Santa buddy is waiting for you to add some items to your wishlist.
+                You've been invited to %owner%'s party. This party is coming soon and that's why we're bringing you a quick update on what to expect.
 
-                Click the link below and add some stuff to your wishlist you'd like.
+                If you haven't confirmed your participation or if you haven't filled in your wishlist, click the link down below and contribute to a great party!
+        btn_pool_update: Check your buddy and wishlist
     forgot_link:
         text: 'Hi there, <br /><br />You have requested us to resend your activation mail with the event manage link(s)<br />'
         subject: 'Resend activation mail'
@@ -394,6 +399,8 @@ flashes:
     forgot_manage_link:
         success: 'We have successfully resend your activation mail'
         error: 'An error occurred while resending the activation mail. Please try again.'
+    pool_update:
+        success: <h4>Success</h4> An update has been sent to all participants.
 forgot_manage_link:
     title: 'Resend activation mail'
     description: 'Fill in the email address of the pool owner and we will resend the activation email. It only works for pools which took place in the past week or will be held in the future. (This will only send the admin page link)'

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -286,6 +286,7 @@ btn:
     update_wishlist: Update your wishlist
     expose: Send me all the matches
     expose_confirm: I understand the consequences, send my Secret Santa mailing list now
+    pool_update: Send party update to participants
     cancel: Cancel
 
 emails:
@@ -354,6 +355,19 @@ emails:
                 Following is an overview of which members are supposed to get gifts for which users.
     poke_buddy:
         subject: Your buddy is waiting for your wishlist
+        message:
+            html: >
+                Dear %name%, <br/>
+                <br/>
+                Your Secret Santa buddy is waiting for you to add some items to your wishlist.<br/>
+                <br/>
+                Click the link below and add some stuff to your wishlist you'd like.
+            txt: >
+                Dear %name%,
+
+                Your Secret Santa buddy is waiting for you to add some items to your wishlist.
+
+                Click the link below and add some stuff to your wishlist you'd like.
     pool_update:
         subject: Our Secret Santa party
         message:
@@ -369,6 +383,8 @@ emails:
                 Dear %name%,
 
                 You've been invited to %owner%'s party. This party is coming soon and that's why we're bringing you a quick update on what to expect.
+
+                Your party takes place %date% in/at %place%. %owner% has invited %participantCount% people and so far %viewedCount% opened the invitation, %wishlistCount% of them added items to their wishlist.
 
                 If you haven't confirmed your participation or if you haven't filled in your wishlist, click the link down below and contribute to a great party!
         btn_pool_update: Check your buddy and wishlist

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
@@ -159,6 +159,7 @@ btn:
     update_wishlist: Actualizar tu lista de deseos
     expose: Enviarme todas las atribuciones
     expose_confirm: Comprendo las consecuencias, enviar mi lista de correos Secret Santa ahora
+    pool_update: Envia una actualizaci&oacute;n a los participantes
     cancel: Cancelar
 
 emails:
@@ -240,6 +241,26 @@ emails:
                 Tu amigote Secret Santa est&aacute; esperando tu lista de deseos.
 
                 Haz clic en el siguiente enlace para a&ntilde;adir cosas a tu lista de deseos.
+    pool_update:
+        subject: Nuestra fiesta Secret Santa
+        message:
+            html: >
+                Estimado %name%,<br/>
+                <br/>
+                %owner% te ha invitado a su fiesta. La fiesta se acerca y por eso os damos una actualizaci&oacute;n en la que peudes esperar.<br/>
+                <br/>
+                Tu fiesta tiene luger en/a %place%. %owner% ha invitado %participantCount% personas y hasta ahora %viewedCount% han abierto la invitaci&oacute;n y %wishlistCount% personas han a&ntilde;adido cosas a su lista de deseos.<br/>
+                <br/>
+                Si no has confirmado tu participaci&oacute;n o si no has rellenado la lista de deseos, haz clic en el siguente enlace para contribuir a una fiesta maravillosa.
+            txt: >
+                Estimado %name%,
+
+                %owner% te ha invitado a su fiesta. La fiesta se acerca y por eso os damos una actualizaci&oacute;n en la que peudes esperar.
+
+                Tu fiesta tiene luger en/a %place%. %owner% ha invitado %participantCount% personas y hasta ahora %viewedCount% han abierto la invitaci&oacute;n y %wishlistCount% personas han a&ntilde;adido cosas a su lista de deseos.
+
+                Si no has confirmado tu participaci&oacute;n o si no has rellenado la lista de deseos, haz clic en el siguente enlace para contribuir a una fiesta maravillosa.
+        btn_pool_update: Comprueba quién es tu amigote o tu lista de deseos.
 flashes:
     manage:
         email_validated: >
@@ -261,3 +282,5 @@ flashes:
         saved_email: <h4>Guardado</h4> Se guardó la nueva dirección de correo electrónico. También reenviamos el correo electrónico.
     analytics:
         invalid_data: <h4>Oops</h4> Ha ocurrido un error al requerir los datos analíticos. Por favor, inténtalo otra vez.
+    pool_update:
+        success: <h4>Éxito</h4> Todos los participantes han recibido una actualizaci&oacute;n sobre la fiesta.

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
@@ -242,24 +242,24 @@ emails:
 
                 Haz clic en el siguiente enlace para a&ntilde;adir cosas a tu lista de deseos.
     pool_update:
-        subject: Nuestra fiesta Secret Santa
+        subject: Nuestra fiesta Secret Santa se acerca!
         message:
             html: >
                 Estimado %name%,<br/>
                 <br/>
-                %owner% te ha invitado a su fiesta. La fiesta se acerca y por eso os damos una actualizaci&oacute;n en la que peudes esperar.<br/>
+                Esperamos que est&eacute;s esperando con impaciencia la fiesta de %owner%. %owner% ha inivitado %participantCount% personas para su fiesta que tiene lugar el %date% en/a %place% y para disfrutar del goce de hacer regalos.<br/>
                 <br/>
-                Tu fiesta tiene luger en/a %place%. %owner% ha invitado %participantCount% personas y hasta ahora %viewedCount% han abierto la invitaci&oacute;n y %wishlistCount% personas han a&ntilde;adido cosas a su lista de deseos.<br/>
+                Para que podemos disfrutar al m&aacute;ximo, ser&iacute;a agradable si cada invitado estar&iacute;a presente y traer&iacute;a un regalo. Hasta ahora %viewedCount% persona(s) ha(n) abierto su invitaci&oacute;n y %wishlistCount% persona(s) ha(n) rempliado un lista de deseos.<br/>
                 <br/>
-                Si no has confirmado tu participaci&oacute;n o si no has rellenado la lista de deseos, haz clic en el siguente enlace para contribuir a una fiesta maravillosa.
+                Haz clic en el siguente enlace para comprobar como est&aacute; tu amigote y hace gestiones para activarlo a pasar a la acci&oacute;n. ¡Eramos pocos y pari&oacute; mi abuela, no cab&iacute;amos al fuego y entr&oacute; nuestro abuelo!
             txt: >
                 Estimado %name%,
 
-                %owner% te ha invitado a su fiesta. La fiesta se acerca y por eso os damos una actualizaci&oacute;n en la que peudes esperar.
+                Esperamos que est&eacute;s esperando con impaciencia la fiesta de %owner%. %owner% ha inivitado %participantCount% personas para su fiesta que tiene lugar el %date% en/a %place% y para disfrutar del goce de hacer regalos.
 
-                Tu fiesta tiene luger en/a %place%. %owner% ha invitado %participantCount% personas y hasta ahora %viewedCount% han abierto la invitaci&oacute;n y %wishlistCount% personas han a&ntilde;adido cosas a su lista de deseos.
+                Para que podemos disfrutar al m&aacute;ximo, ser&iacute;a agradable si cada invitado estar&iacute;a presente y traer&iacute;a un regalo. Hasta ahora %viewedCount% persona(s) ha(n) abierto su invitaci&oacute;n y %wishlistCount% persona(s) ha(n) rempliado un lista de deseos.
 
-                Si no has confirmado tu participaci&oacute;n o si no has rellenado la lista de deseos, haz clic en el siguente enlace para contribuir a una fiesta maravillosa.
+                Haz clic en el siguente enlace para comprobar como est&aacute; tu amigote y hace gestiones para activarlo a pasar a la acci&oacute;n. ¡Eramos pocos y pari&oacute; mi abuela, no cab&iacute;amos al fuego y entr&oacute; nuestro abuelo!
         btn_pool_update: Comprueba quién es tu amigote o tu lista de deseos.
 flashes:
     manage:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
@@ -330,24 +330,24 @@ emails:
 
                 Cliquez sur le boutton ci-dessous afin d'ajouter des choses a votre liste de souhaits.
     pool_update:
-        subject: Notre f&ecirc;te Secret Santa
+        subject: Notre f&ecirc;te Secret Santa s'approche
         message:
             html: >
                 Cher(e) %name%, <br>
                 <br>
-                %owner% vous a invité à lui joindre à une f&ecirc;te. Cette f&ecirc;te s'approche et pour ça nous vous allons donner une mise à jour pour que vous savez ce que vous pouvez vous attendre.<br/>
+                Nous esperons que vous guettez la f&ecirc;te de %owner% qui s'approche. %owner% attend %participantCount% personnes &agrave; sa f&ecirc;te le %date% chez/&agrave; %place% pour jouir le plaisir de faire cadeau des choses aux autres.<br/>
                 <br/>
-                Votre f&ecirc;te aura lieu %date% &agrave;/chez %place%. %owner% a invité %participantCount% persone(s) et jusqu'&agrave; pr&eacute;sent %viewedCount% persone(s) ont ouvert l'invitation, %wishlistCount% persone(s) ont ajouté des choses &agrave; leur liste de souhaits.<br/>
+                Pour qu'on puisse donner beaucoup de plaisir &agrave; tout le monde, serait agr&eacute;able si chaque invit&eacute; assiterait &agrave; la f&ecirc;te y apporterait un cadeau. Jusqu'&agrave; pr&eacute;sent %viewedCount% personnes ont ouvert leur invitation et %wishlistCount% ont rempli leur liste de souhaits.<br/>
                 <br/>
-                Si vous n'avez pas encore confirmé votre participation ou vous n'avez pas encore remplis votre liste des objets d&eacute;sir&eacute, cliquez sur le boutton ci-dessous afin de contribuer à une f&eacute;te formidable.
+                Cliquez sur le boutton ci-dessous afin de controler le point o&ugrave; en est votre copain et passe &agrave; l'action si c'est n&eacute;cessaire pour qu'il prend part &agrave; la f&ecirc;te. Plus on est de fous, plus on rit!
             txt: >
                 Cher(e) %name%,
 
-                %owner% vous a invité à lui joindre à une f&ecirc;te. Cette f&ecirc;te s'approche et pour ça nous vous allons donner une mise à jour pour que vous savez ce que vous pouvez vous attendre.
+                Nous esperons que vous guettez la f&ecirc;te de %owner% qui s'approche. %owner% attend %participantCount% personnes &agrave; sa f&ecirc;te le %date% chez/&agrave; %place% pour jouir le plaisir de faire cadeau des choses aux autres.
 
-                Votre f&ecirc;te aura lieu %date% &agrave;/chez %place%. %owner% a invité %participantCount% persone(s) et jusqu'&agrave; pr&eacute;sent %viewedCount% persone(s) ont ouvert l'invitation, %wishlistCount% persone(s) ont ajouté des choses &agrave; leur liste de souhaits.
+                Pour qu'on peut donner beaucoup de plaisir &agrave; tout le monde, serait agr&eacute;able si chaque invit&eacute; assiterait &agrave; la f&ecirc;te y apporterait un cadeau. Jusqu'&agrave; pr&eacute;sent %viewedCount% personnes ont ouvert leur invitation et %wishlistCount% ont rempli leur liste de souhaits.
 
-                Si vous n'avez pas encore confirmé votre participation ou vous n'avez pas encore remplis votre liste des objets d&eacute;sir&eacute, cliquez sur le boutton ci-dessous afin de contribuer à une f&eacute;te formidable.
+                Cliquez sur le boutton ci-dessous afin de controler le point o&ugrave; en est votre copain et passe &agrave; l'action si c'est n&eacute;cessaire pour qu'il prend part &agrave; la f&ecirc;te. Plus on est de fous, plus on rit!
         btn_pool_update: Contr&ocirc;le v&ocirc;tre copain ou liste de souhaits.
 flashes:
     manage:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
@@ -247,6 +247,7 @@ btn:
     update_wishlist: Mettre à jour votre liste de souhaits
     expose: Envoyez-moi toutes les attributions
     expose_confirm: J'ai compris les cons&eacute;quences, envoyez-moi la liste Secret Santa maintenant
+    pool_update: Envoie une mise &agrave; jour &agrave; tous les participants
     cancel: Annuler
 
 emails:
@@ -328,6 +329,26 @@ emails:
                 Votre copain Secret Santa est en attente de votre liste de souhaits.
 
                 Cliquez sur le boutton ci-dessous afin d'ajouter des choses a votre liste de souhaits.
+    pool_update:
+        subject: Notre f&ecirc;te Secret Santa
+        message:
+            html: >
+                Cher(e) %name%, <br>
+                <br>
+                %owner% vous a invité à lui joindre à une f&ecirc;te. Cette f&ecirc;te s'approche et pour ça nous vous allons donner une mise à jour pour que vous savez ce que vous pouvez vous attendre.<br/>
+                <br/>
+                Votre f&ecirc;te aura lieu %date% &agrave;/chez %place%. %owner% a invité %participantCount% persone(s) et jusqu'&agrave; pr&eacute;sent %viewedCount% persone(s) ont ouvert l'invitation, %wishlistCount% persone(s) ont ajouté des choses &agrave; leur liste de souhaits.<br/>
+                <br/>
+                Si vous n'avez pas encore confirmé votre participation ou vous n'avez pas encore remplis votre liste des objets d&eacute;sir&eacute, cliquez sur le boutton ci-dessous afin de contribuer à une f&eacute;te formidable.
+            txt: >
+                Cher(e) %name%,
+
+                %owner% vous a invité à lui joindre à une f&ecirc;te. Cette f&ecirc;te s'approche et pour ça nous vous allons donner une mise à jour pour que vous savez ce que vous pouvez vous attendre.
+
+                Votre f&ecirc;te aura lieu %date% &agrave;/chez %place%. %owner% a invité %participantCount% persone(s) et jusqu'&agrave; pr&eacute;sent %viewedCount% persone(s) ont ouvert l'invitation, %wishlistCount% persone(s) ont ajouté des choses &agrave; leur liste de souhaits.
+
+                Si vous n'avez pas encore confirmé votre participation ou vous n'avez pas encore remplis votre liste des objets d&eacute;sir&eacute, cliquez sur le boutton ci-dessous afin de contribuer à une f&eacute;te formidable.
+        btn_pool_update: Contr&ocirc;le v&ocirc;tre copain ou liste de souhaits.
 flashes:
     manage:
         email_validated: >
@@ -347,3 +368,5 @@ flashes:
         poke_buddy: <h4>Stimulé</h4> Nos gnomes sont en route pour avertir votre copain Secret Santa que leur liste de souhaits est vide.
         edit_email: <h4>Non enregistrée</h4> Il y a une erreur dans l'adresse e-mail.
         saved_email: <h4>Enregistrée</h4> La nouvelle adresse e-mail a été enregistrée. Nous avons également renvoyé l'e-mail.
+    pool_update:
+        success: <h4>Succ&egrave;s</h4> Votre participants ont reçu une mise &agrave; jour sur la f&ecirc;te.

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -267,6 +267,7 @@ btn:
     update_wishlist: Update je verlanglijst
     expose: Stuur me alle koppelingen
     expose_confirm: Ik begrijp de gevolgen, stuur mij nu alle koppelingen
+    pool_update: Verstuur update naar alle deelnemers
     cancel: Annuleren
 
 emails:
@@ -348,6 +349,26 @@ emails:
                 Jouw Secret Santa maatje wacht op jouw wenslijst.
 
                 Klik op de onderstaande link en voeg dingen toe aan jouw wenslijst.
+    pool_update:
+        subject: Ons Secret Santa feestje
+        message:
+            html: >
+                Beste %name%,<br>
+                <br>
+                %owner% heeft je uitgenodigd voor een Secret Santa feestje. Dit feestje komt er snel aan een brengen we je nu een update zodat je weet wat je te wachten staat.<br/>
+                <br/>
+                Je feestje gaat door op %date% in/bij %place%. %owner% heeft %participantCount% mensen uitgenodigd en momenteel is de uitnodiging bekeken door %viewedCount% perso(o)n(en) en %wishlistCount% mens(en) hebben dingen toegevoegd aan hun verlanglijst.<br/>
+                <br/>
+                Indien je je deelname nog niet hebt bevestigd of je wenslijst nog niet hebt ingevuld, klik dan op de onderstaande link en zorg mee voor een geweldig feestje.
+            txt: >
+                Beste %name%,
+
+                %owner% heeft je uitgenodigd voor een Secret Santa feestje. Dit feestje komt er snel aan een brengen we je nu een update zodat je weet wat je te wachten staat.
+
+                Je feestje gaat door op %date% in/bij %place%. %owner% heeft %participantCount% mensen uitgenodigd en momenteel is de uitnodiging bekeken door %viewedCount% perso(o)n(en) en %wishlistCount% mens(en) hebben dingen toegevoegd aan hun verlanglijst.
+
+                Indien je je deelname nog niet hebt bevestigd of je wenslijst nog niet hebt ingevuld, klik dan op de onderstaande link en zorg mee voor een geweldig feestje.
+        btn_pool_update: Check wie je maatje is en vul je wenslijst in
     forgot_link:
         text: 'Hallo, <br /><br />U heeft ons gevraagd om de activatie mail met de link(s) naar de beheerpagina opnieuw te verzenden<br />'
         subject: 'Activatie mail opnieuw verzenden'
@@ -373,6 +394,8 @@ flashes:
     forgot_manage_link:
         success: 'De activatie mail is succesvol opnieuw verstuurd!'
         error: 'Er is een fout opgetreden tijdens het versturen van de activatie mail. Probeer nogmaals.'
+    pool_update:
+        success: <h4>Succes</h4> Alle deelnemers hebben een update over het feestje ontvangen.
 forgot_manage_link:
     title: 'Activatie mail opnieuw verzenden'
     description: 'Vul hier het emailadres van de eigenaar van het evenement in en wij versturen de activatie mail opnieuw. Dit is alleen mogelijk voor feestjes die plaatsvonden in de voorbije week of nog moeten plaatsvinden. (Hiermee wordt alleen de beheerpagina link gestuurd)'

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -350,24 +350,24 @@ emails:
 
                 Klik op de onderstaande link en voeg dingen toe aan jouw wenslijst.
     pool_update:
-        subject: Ons Secret Santa feestje
+        subject: Ons Secret Santa feestje komt eraan!
         message:
             html: >
                 Beste %name%,<br>
                 <br>
-                %owner% heeft je uitgenodigd voor een Secret Santa feestje. Dit feestje komt er snel aan een brengen we je nu een update zodat je weet wat je te wachten staat.<br/>
+                We hopen dat je uitkijkt naar feestje van %owner% dat er binnenkort aankomt. %owner% verwacht %participantCount% mensen op het feestje op %date% in/bij %place% om het plezier van cadeautjes uitdelen met elkaar te delen.<br/>
                 <br/>
-                Je feestje gaat door op %date% in/bij %place%. %owner% heeft %participantCount% mensen uitgenodigd en momenteel is de uitnodiging bekeken door %viewedCount% perso(o)n(en) en %wishlistCount% mens(en) hebben dingen toegevoegd aan hun verlanglijst.<br/>
+                Om zoveel mogelijk plezier te beleven, zou het leuk zijn als elke uitgenodigde persoon zou langskomen op het feestje en een cadeautje zou meebrengen. Tot nu toe hebben %viewedCount% perso(o)n(en) hun uitnodiging geopend en hebben er %wishlistCount% hun verlanglijstje ingevuld.<br/>
                 <br/>
-                Indien je je deelname nog niet hebt bevestigd of je wenslijst nog niet hebt ingevuld, klik dan op de onderstaande link en zorg mee voor een geweldig feestje.
+                Klik op de onderstaande link om te checken hoe je maatje ervoor staat en onderneem actie indien nodig om ook hen te overtuigen om deel te nemen. Hoe meer zielen, hoe meer vreugd!
             txt: >
                 Beste %name%,
 
-                %owner% heeft je uitgenodigd voor een Secret Santa feestje. Dit feestje komt er snel aan een brengen we je nu een update zodat je weet wat je te wachten staat.
+                We hopen dat je uitkijkt naar feestje van %owner% dat er binnenkort aankomt. %owner% verwacht %participantCount% mensen op het feestje op %date% in/bij %place% om het plezier van cadeautjes uitdelen met elkaar te delen.
 
-                Je feestje gaat door op %date% in/bij %place%. %owner% heeft %participantCount% mensen uitgenodigd en momenteel is de uitnodiging bekeken door %viewedCount% perso(o)n(en) en %wishlistCount% mens(en) hebben dingen toegevoegd aan hun verlanglijst.
+                Om zoveel mogelijk plezier te beleven, zou het leuk zijn als elke uitgenodigde persoon zou langskomen op het feestje en een cadeautje zou meebrengen. Tot nu toe hebben %viewedCount% perso(o)n(en) hun uitnodiging geopend en hebben er %wishlistCount% hun verlanglijstje ingevuld.
 
-                Indien je je deelname nog niet hebt bevestigd of je wenslijst nog niet hebt ingevuld, klik dan op de onderstaande link en zorg mee voor een geweldig feestje.
+                Klik op de onderstaande link om te checken hoe je maatje ervoor staat en onderneem actie indien nodig om ook hen te overtuigen om deel te nemen. Hoe meer zielen, hoe meer vreugd!
         btn_pool_update: Check wie je maatje is en vul je wenslijst in
     forgot_link:
         text: 'Hallo, <br /><br />U heeft ons gevraagd om de activatie mail met de link(s) naar de beheerpagina opnieuw te verzenden<br />'

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/poolupdate.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/poolupdate.html.twig
@@ -39,7 +39,7 @@
                                 <tr>
                                     <td height="40" valign="middle" style="background-color:#bd1019;">
                                         <a href="{{ url('entry_view', { 'url': entry.url }) }}" target="_blank" style="font-family: Arial, Helvetica, sans-serif;background-color:#bd1019;font-size:18px;color:#ffffff;text-decoration: none;display:block;line-height: 40px;height: 40px">
-                                            {{ 'emails.pool_update.btn_pool_update'|trans }}
+                                            {{ 'emails.pool_update.btn_pool_update'|trans|raw }}
                                         </a>
                                     </td>
                                 </tr>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/poolupdate.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/poolupdate.html.twig
@@ -1,0 +1,66 @@
+{% extends 'IntractoSecretSantaBundle:Emails:basemail.html.twig' %}
+{% block main %}
+    <table width="640" border="0" cellpadding="0" cellspacing="0" align="center" style="font-family: Arial, Helvetica, sans-serif; font-size: 15px; color:#333333; line-height: 25px;">
+        <tr>
+            <td width="37" align="left">
+                <img src="http://www.eproof.be/assets/intracto/secret-santa/x.gif" width="37" style="display:block;" border="0" />
+            </td>
+            <td width="566">
+                <p>{{ 'emails.pool_update.message.html'|trans({'%name%': entry.name, '%owner%': results['pool'][0]['adminName'], '%date%': results['pool'][0]['eventdate']|date('Y-m-d'), '%place%': results['pool'][0]['location'], '%participantCount%': results['participantCount'][0]['participantCount'], '%viewedCount%': results['viewedCount'][0]['viewedCount'], '%wishlistCount%': results['wishlistCount'][0]['wishlistCount'] })|raw }}</p>
+            </td>
+            <td width="37" align="right">
+                <img src="http://www.eproof.be/assets/intracto/secret-santa/x.gif" width="37" style="display:block;" border="0" />
+            </td>
+        </tr>
+        <tr>
+            <td width="640" colspan="3">
+                <table border="0" cellpadding="0" cellspacing="0">
+                    <tr>
+                        <td width="52" height="45" valign="top">
+                            <img src="http://www.eproof.be/assets/intracto/secret-santa/left-btn.jpg" width="52" height="45" style="display:block;" border="0" />
+                        </td>
+                        <td height="45" valign="top">
+                            <table border="0" cellpadding="0" cellspacing="0" height="45">
+                                <tr>
+                                    <td height="1" style="line-height: 1px;background-color: #ffffff" valign="top">
+                                        <img src="http://www.eproof.be/assets/intracto/secret-santa/x.gif" height="1" style="display:block;" border="0" />
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td height="1" style="line-height: 1px;background-color: #a9181b" valign="top">
+                                        <img src="http://www.eproof.be/assets/intracto/secret-santa/x.gif" height="1" style="display:block;" border="0" />
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td height="1" style="line-height: 1px;background-color: #ea1e35" valign="top">
+                                        <img src="http://www.eproof.be/assets/intracto/secret-santa/x.gif" height="1" style="display:block;" border="0" />
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td height="40" valign="middle" style="background-color:#bd1019;">
+                                        <a href="{{ url('entry_view', { 'url': entry.url }) }}" target="_blank" style="font-family: Arial, Helvetica, sans-serif;background-color:#bd1019;font-size:18px;color:#ffffff;text-decoration: none;display:block;line-height: 40px;height: 40px">
+                                            {{ 'emails.pool_update.btn_pool_update'|trans }}
+                                        </a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td height="1" style="line-height: 1px;background-color: #d31927" valign="top">
+                                        <img src="http://www.eproof.be/assets/intracto/secret-santa/x.gif" height="1" style="display:block;" border="0" />
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td height="1" style="line-height: 1px;background-color: #a91721" valign="top">
+                                        <img src="http://www.eproof.be/assets/intracto/secret-santa/x.gif" height="1" style="display:block;" border="0" />
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                        <td width="59" height="45" valign="top">
+                            <img src="http://www.eproof.be/assets/intracto/secret-santa/right-btn.jpg" width="59" height="45" style="display:block;" border="0" />
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+{% endblock %}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/poolupdate.txt.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/poolupdate.txt.twig
@@ -1,0 +1,6 @@
+{{ 'emails.pool_update.message.txt'|trans({'%name%': entry.name, '%owner%': results['pool'][0]['adminName'], '%date%': results['pool'][0]['eventdate']|date('Y-m-d'), '%place%': results['pool'][0]['location'], '%participantCount%': results['participantCount'][0]['participantCount'], '%viewedCount%': results['viewedCount'][0]['viewedCount'], '%wishlistCount%': results['wishlistCount'][0]['wishlistCount'] })|raw }}
+
+{{ 'emails.pool_update.btn_pool_update'|trans }}
+{{ url('entry_view', { 'url': entry.url, '_locale': entry.pool.locale }) }}
+
+{{ 'emails.base.created_by'|trans }} http://www.intracto.com

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/poolupdate.txt.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/poolupdate.txt.twig
@@ -1,6 +1,6 @@
 {{ 'emails.pool_update.message.txt'|trans({'%name%': entry.name, '%owner%': results['pool'][0]['adminName'], '%date%': results['pool'][0]['eventdate']|date('Y-m-d'), '%place%': results['pool'][0]['location'], '%participantCount%': results['participantCount'][0]['participantCount'], '%viewedCount%': results['viewedCount'][0]['viewedCount'], '%wishlistCount%': results['wishlistCount'][0]['wishlistCount'] })|raw }}
 
-{{ 'emails.pool_update.btn_pool_update'|trans }}
+{{ 'emails.pool_update.btn_pool_update'|trans|raw }}
 {{ url('entry_view', { 'url': entry.url, '_locale': entry.pool.locale }) }}
 
 {{ 'emails.base.created_by'|trans }} http://www.intracto.com

--- a/src/Intracto/SecretSantaBundle/Resources/views/Pool/manage.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Pool/manage.html.twig
@@ -54,7 +54,7 @@
 
         <button id="btn_delete" class="btn btn-primary"><i class="icon-warning-sign icon-white"></i> {{ 'btn.delete_list'|trans }}</button>
         <button id="btn_expose" class="btn btn-warning"><i class="icon-eye-open icon-white"></i> {{ 'btn.expose'|trans }}</button>
-        <a class="btn btn-info" href="{{ path('pool_update', { 'listUrl': pool.listurl }) }}">Send pool update to users</a>
+        <a class="btn btn-info" href="{{ path('pool_update', { 'listUrl': pool.listurl }) }}">{{ 'btn.pool_update'|trans|raw }}</a>
 
         <br/><br/>
 

--- a/src/Intracto/SecretSantaBundle/Resources/views/Pool/manage.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Pool/manage.html.twig
@@ -54,6 +54,7 @@
 
         <button id="btn_delete" class="btn btn-primary"><i class="icon-warning-sign icon-white"></i> {{ 'btn.delete_list'|trans }}</button>
         <button id="btn_expose" class="btn btn-warning"><i class="icon-eye-open icon-white"></i> {{ 'btn.expose'|trans }}</button>
+        <a class="btn btn-info" href="{{ path('pool_update', { 'listUrl': pool.listurl }) }}">Send pool update to users</a>
 
         <br/><br/>
 


### PR DESCRIPTION
Follows up on #94 
Subissue of #93

Admin can send an update on the party status to all participants by clicking a link on his manage-page. Participants get an overview on where and when the party will take place and gets to see how many people the admin invited, how many people already confirmed their participation and how many people already added items to their wishlist. This should encourage participants to take action if needed.