### PR TITLE
Expose wishlists to admin

### DIFF
--- a/src/Intracto/SecretSantaBundle/Controller/PoolController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/PoolController.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\EntityRepository;
 use JMS\DiExtraBundle\Annotation as DI;
 use Intracto\SecretSantaBundle\Entity\Pool;
 use Intracto\SecretSantaBundle\Form\PoolType;
+use Intracto\SecretSantaBundle\Mailer\MailerService;
 
 class PoolController extends Controller
 {
@@ -263,6 +264,10 @@ class PoolController extends Controller
         }
 
         $this->getPool($listUrl);
+        $this->pool->exposeWishlists();
+
+        $em = $this->getDoctrine()->getManager();
+        $em->flush();
 
         $this->mailerService->sendAllWishlistsToAdmin($this->pool);
 

--- a/src/Intracto/SecretSantaBundle/Entity/Pool.php
+++ b/src/Intracto/SecretSantaBundle/Entity/Pool.php
@@ -102,6 +102,13 @@ class Pool
     private $exposed = false;
 
     /**
+     * @var bool $wishlists_exposed
+     *
+     * @ORM\Column(name="wishlists_exposed", type="boolean")
+     */
+    private $wishlistsExposed = false;
+
+    /**
      * @var string $location
      *
      * @Assert\NotBlank()
@@ -386,6 +393,24 @@ class Pool
     public function getExposed()
     {
         return $this->exposed;
+    }
+
+    /**
+     * @return Pool
+     */
+    public function exposeWishlists()
+    {
+        $this->wishlistsExposed = true;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getWishlistsExposed()
+    {
+        return $this->wishlistsExposed;
     }
 
     /**

--- a/src/Intracto/SecretSantaBundle/Mailer/MailerService.php
+++ b/src/Intracto/SecretSantaBundle/Mailer/MailerService.php
@@ -136,6 +136,37 @@ class MailerService
     }
 
     /**
+     * @param Pool $pool
+     */
+    public function sendAllWishlistsToAdmin(Pool $pool)
+    {
+        $this->translator->setLocale($pool->getLocale());
+        $this->mailer->send(\Swift_Message::newInstance()
+            ->setSubject($this->translator->trans('emails.admin_wishlists.subject'))
+            ->setFrom($this->adminEmail, $this->translator->trans('emails.sender'))
+            ->setTo($pool->getOwnerEmail(), $pool->getOwnerName())
+            ->setBody(
+                $this->templating->render(
+                    'IntractoSecretSantaBundle:Emails:admin_wishlists.html.twig',
+                    [
+                        'pool' => $pool,
+                    ]
+                ),
+                'text/html'
+            )
+            ->addPart(
+                $this->templating->render(
+                    'IntractoSecretSantaBundle:Emails:admin_wishlists.txt.twig',
+                    [
+                        'pool' => $pool,
+                    ]
+                ),
+                'text/plain'
+            )
+        );
+    }
+
+    /**
      * @param $email
      * @return bool
      */

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -105,7 +105,7 @@ expose:
         </p>
     phrase_to_type: show me everything
 expose_wishlists:
-    title: Send me all wishlists in this maling list
+    title: Send me all wishlists in this mailing list
     body: >
         <p>
             Are you ABSOLUTELY sure?<br>

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -104,6 +104,20 @@ expose:
             Please type "<b>%phrase_to_type%</b>" below to confirm.<br>
         </p>
     phrase_to_type: show me everything
+expose_wishlists:
+    title: Send me all wishlists in this maling list
+    body: >
+        <p>
+            Are you ABSOLUTELY sure?<br>
+            <br>
+            A mail will be send to you, containing the wishlists of all people in your mailing list.<br>
+            <br>
+            <b>Be aware:</b><br>
+            ONLY YOU will receive all the wishlists, but all the others will see that you requested them.<br>
+            <br>
+            Please type "<b>%phrase_to_type%</b>" below to confirm.<br>
+        </p>
+    phrase_to_type: show me all wishlists
 entry:
     headers:
         title: Your <span class="accent">Secret Santa party</span> details
@@ -269,6 +283,7 @@ label:
     actions: Actions
     description: Description
     wishlist_filled: Wish List Entered
+    items: Wishlist items
 placeholder:
     exclude: Click and choose the participants you want to exclude
 btn:
@@ -286,9 +301,10 @@ btn:
     update_wishlist: Update your wishlist
     expose: Send me all the matches
     expose_confirm: I understand the consequences, send my Secret Santa mailing list now
+    expose_wishlists: Send me all the wishlists
+    expose_wishlists_confirm: I understand the consequences, send me all wishlists now
     pool_update: Send party update to participants
     cancel: Cancel
-
 emails:
     sender: Santa Claus
     base:
@@ -404,6 +420,21 @@ emails:
 
                 Click the link below to resend mails, edit emailaddresses or to perform more actions related to your pool.
         btn_poolstatus: Manage your party
+    admin_wishlists:
+        subject: Secret Santa Mailing Wishlists
+        message:
+            html: >
+                Dear %owner%,<br/>
+                <br/>
+                You have requested all wishlists of people in your mailing list. Please be aware that all the members will be able to see this on their wishlist page.<br/>
+                <br/>
+                Following is an overview of each member and their desired Secret Santa presents.
+            txt: >
+                Dear %owner%,
+
+                You have requested all wishlists of people in your mailing list. Please be aware that all the members will be able to see this on their wishlist page.
+
+                Following is an overview of each member and their desired Secret Santa presents.
     forgot_link:
         text: 'Hi there, <br /><br />You have requested us to resend your activation mail with the event manage link(s)<br />'
         subject: 'Resend activation mail'
@@ -419,6 +450,9 @@ flashes:
     expose:
         not_exposed: <h4>Mailing list not send</h4> The confirmation was incorrect.
         exposed: <h4>Mailing list send</h4> All users will be notified when they check their wishlist.
+    expose_wishlists:
+        not_exposed: <h4>Wishlists not send</h4> The confirmation was incorrect.
+        exposed: <h4>Wishlists send</h4> All users will be notified when they check their wishlist.
     resend:
         resent: <strong>Resent!</strong><br/>The e-mail to %email% has been resent.<br/>
     entry:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -128,6 +128,8 @@ entry:
         person_created_list: Person who created this list
         exposed: Mailing list creator knows all matches
         not_exposed: Mailing list creator does not know all matches
+        wishlists_exposed: Mailing list creator has all the wishlists
+        wishlists_not_exposed: Mailing list creater does not have all the wishlists
     title: Your assigned buddy
     body: >
         <p>Hi %name%,</p>

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
@@ -101,6 +101,17 @@ expose:
             Por favor, escribe "<b>%phrase_to_type%</b>" debajo para confirmar.<br>
         </p>
     phrase_to_type: mostrarme todo
+expose_wishlists:
+    title: Enviarme todas las listas de deseos en esta lista de correos
+    body: >
+        <p>
+            ¿Estás COMPLETAMENTE seguro?<br>
+            <br>
+            Se te enviará un correo electónico, con todas listas de deseos de las personas en la lista de correos!<br>
+            <br>
+            Por favor, escribe "<b>%phrase_to_type%</b>" debajo para confirmar.<br>
+        </p>
+    phrase_to_type: mostrarme todas las listas de deseos
 entry:
     headers:
         title: Tus datos de la <span class="accent">fiesta Secret Santa</span>
@@ -142,6 +153,7 @@ label:
     confirmed: Confirmado
     actions: Acciones
     description: Descripción
+    items: Regalos deseados
 placeholder:
     exclude: Hacer clic y elegir los participantes que se quiere excluir
 btn:
@@ -159,6 +171,8 @@ btn:
     update_wishlist: Actualizar tu lista de deseos
     expose: Enviarme todas las atribuciones
     expose_confirm: Comprendo las consecuencias, enviar mi lista de correos Secret Santa ahora
+    expose_wishlists: Enviarme todas las listas de deseos
+    expose_wishlists_confirm: Comprendo las consecuencias, enviar todas las listas de deseos ahore
     pool_update: Envia una actualizaci&oacute;n a los participantes
     cancel: Cancelar
 
@@ -277,6 +291,21 @@ emails:
 
                 Haz clic en el siguiente enlace para llevar tu fiesta.
         btn_poolstatus: Gestiona tu fiesta
+    admin_wishlists:
+        subject: Secret Santa Listas de deseos
+        message:
+            html: >
+                Estimado %owner%,<br/>
+                <br/>
+                Has solicitado todas las listas de deseos de personas en tu lista de Correos. Por favor, ten en cuenta que todos los miembros prodrán ver eso en su página de la lista de deseos.<br/>
+                <br/>
+                A continuación un resumen de cada miembro y sus regalos deseados.
+            txt: >
+                Estimado %owner%,
+
+                Has solicitado todas las listas de deseos de personas en tu lista de Correos. Por favor, ten en cuenta que todos los miembros prodrán ver eso en su página de la lista de deseos.
+
+                A continuación un resumen de cada miembro y sus regalos deseados.
 flashes:
     manage:
         email_validated: >
@@ -289,6 +318,9 @@ flashes:
     expose:
         not_exposed: <h4>No enviar lista de correos </h4> La confirmación era incorrecta.
         exposed: <h4>Enviar lista de correos</h4> Se notificará a todos los usuarios cuando comprueben su lista de deseos.
+    expose_wishlists:
+        not_exposed: <h4>No envier listas de deseos</h4> La confirmación era incorrecta.
+        exposed: <h4>Enviar listas de deseos</h4> Se notificará a todos los usuarios cuando comprueben su lista de deseos.
     resend:
         resent: <strong>¡Reenviado!</strong><br/>El correo electrónico %email% ha sido reenviado.<br/>
     entry:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
@@ -122,6 +122,8 @@ entry:
         person_created_list: Persona que creó esta lista
         exposed: El creador de la lista de correos conoce todas las atribuciones
         not_exposed: El creador de la lista de correos no conoce todas las atribuciones
+        wishlists_exposed: El creador de la lista de correos conoce todas las listas de deseos
+        wishlists_not_exposed: El creador de la lista de correos no conoce todas las listas de deseos
     title: Tu amigo asignado
     body: >
         <p>Hola %name%,</p>

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
@@ -99,6 +99,20 @@ expose:
             Entrez svp "<b>%phrase_to_type%</b>" ci-dessous afin de confirmer.<br>
         </p>
     phrase_to_type: Montrez-moi tout
+expose_wishlists:
+    title: Envoyer-moi toutes les listes de souhaits par e-mail
+    body: >
+        <p>
+            Etes-vous ABSOLUMENT certain?<br>
+            <br>
+            Un e-mail va vous &ecirc;tre envoy&eacute;, contenant les listes de souhaits de votre f&ecirc;te.
+            <br>
+            <b>Avertissement:</b><br>
+            Vous serez la SEULE personne à recevoir les correspondances, mais les autres verront que vous avez obtenu la liste.<br>
+            <br>
+            Entrez svp "<b>%phrase_to_type%</b>" ci-dessous afin de confimer.<br>
+        </p>
+    phrase_to_type: Montrez-moi tous les listes de souhaits
 entry:
     headers:
         title: Détails de votre <span class="accent">Secret Santa party</span>
@@ -230,6 +244,7 @@ label:
     confirmed: Confirmés
     actions: Actions
     description: Déscription
+    items: Cadeaux désirés
 placeholder:
     exclude: Cliquez et sélectionnez les partipants que vous désirez exclure
 btn:
@@ -247,9 +262,10 @@ btn:
     update_wishlist: Mettre à jour votre liste de souhaits
     expose: Envoyez-moi toutes les attributions
     expose_confirm: J'ai compris les cons&eacute;quences, envoyez-moi la liste Secret Santa maintenant
+    expose_wishlists: Envoyez-moi toutes les listes de souhaits
+    expose_wishlists_confirm: J'ai compris les cons&eacute;quences, envoyer-moi les listes de souhaits maintenant
     pool_update: Envoie une mise &agrave; jour &agrave; tous les participants
     cancel: Annuler
-
 emails:
     sender: Santa Claus
     base:
@@ -365,6 +381,21 @@ emails:
 
                 Cliquez sur le boutton ci-dessous afin d'administrer votre f&ecirc;te.
         btn_poolstatus: Manage votre f&ecirc;te
+    admin_wishlists:
+        subject: Listes de souhaits Secret Santa
+        message:
+            html: >
+                Cher(e) %owner%,<br/>
+                <br/>
+                Vous avez demand&eacute; à conna&icirc;tre toutes les listes de souhaits de votre liste. Sachez que chaque membre en sera inform&eactue; sur sa liste de souhatis.<br/>
+                <br/>
+                Ci-dessous, la liste des chaque membre et leur cadeaux désirés.
+            txt: >
+                Cher(e) %owner%,
+
+                Vous avez demand&eacute; à conna&icirc;tre toutes les listes de souhaits de votre liste. Sachez que chaque membre en sera inform&eactue; sur sa liste de souhatis.
+
+                Ci-dessous, la liste des chaque membre et leur cadeaux désirés.
 flashes:
     manage:
         email_validated: >
@@ -377,6 +408,9 @@ flashes:
     expose:
         not_exposed: <h4>Liste non envoy&eacute;e</h4> La phrase de confirmation est incorrecte.
         exposed: <h4>Liste envoy&eacute;e</h4> Chaque membre en sera inform&eacute; lorsqu'ils consulteront leur liste de souhaits.
+    expose_wishlists:
+        not_exposed: <h4>Listes de souhaits non envoy&eacute;es</h4> La phrase de confirmation est incorrecte.
+        exposed: <h4>Listes de souhaits envoy&eacute;es</h4> Chaque membre en sera inform&eacute; lorsu'ils consulteront leur liste de souhaits.
     resend:
         resent: <strong>Renvoyé !</strong><br/>L'e-mail à %email% a bien été renvoyé.<br/>
     entry:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
@@ -123,6 +123,8 @@ entry:
         person_created_list: Créateur de la liste
         exposed: Le cr&eacute;ateur de la liste conna&icirc;t toutes les attributions
         not_exposed: Le cr&eacute;ateur de la liste ne conna&icirc;t pas les attributions
+        wishlists_exposed: Le cr&eacute;ateur de la liste conna&icirc;t toutes les listes de souhaits
+        wishlists_not_exposed: Le cr&eacute;ateur de la liste ne conna&icirc;t pas toutes les listes de souhaits
     title: Personne désignée
     body: >
         <p>Bonjour %name%,</p>

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -125,6 +125,8 @@ entry:
         person_created_list: Persoon die deze lijst samenstelde
         exposed: Lijst maker kent alle koppelingen
         not_exposed: Lijst maker kent de koppelingen niet
+        wishlists_exposed: Lijst maker kent alle wenslijsten
+        wishlists_not_exposed: Lijst maker kent niet alle wenslijsten
     title: Jouw toegewezen maatje
     body: >
         <p>Hey %name%,</p>

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -101,6 +101,20 @@ expose:
             <br>Typ "<b>%phrase_to_type%</b>" onderaan om te bevestigen.<br>
         </p>
     phrase_to_type: toon me alles
+expose_wishlists:
+    title: Toon alle verlanglijstjes in deze mailinglijst
+    body: >
+        <p>
+            Weet je het ECHT zeker?<br>
+            <br>
+            Er word een mail naar u verzonden, waarin alle verlanglijstjes van mensen in deze mailinglijst vermeld zullen staan.<br>
+            <br>
+            <b>Pas op:</b><br>
+            ENKEL JIJ krijgt de verlanglijstjes toegestuurd, maar alle leden zullen zien dat jij de lijst hebt opgevraagd.<br>
+            <br>
+            <br>Typ "<b>%phrase_to_type%</b>" onderaan om te bevestigen.<br>
+        </p>
+    phrase_to_type: toon me alle verlanglijstjes
 entry:
     headers:
         title: Jouw <span class="accent">Secret Santa party</span> details
@@ -250,6 +264,7 @@ label:
     actions: Acties
     description: Beschrijving
     wishlist_filled: Wish List Ingevuld
+    items: Gewenste verrassingen
 placeholder:
     exclude: Klik en kies de deelnemers die je wilt uitsluiten
 btn:
@@ -267,6 +282,8 @@ btn:
     update_wishlist: Update je verlanglijst
     expose: Stuur me alle koppelingen
     expose_confirm: Ik begrijp de gevolgen, stuur mij nu alle koppelingen
+    expose_wishlists: Stuur me alle verlanglijstjes
+    expose_wishlists_confirm: Ik begrijp de gevolgen, stuur mij nu alle verlanglijstjes
     pool_update: Verstuur update naar alle deelnemers
     cancel: Annuleren
 
@@ -325,13 +342,13 @@ emails:
             html: >
                 Beste %owner%,<br/>
                 <br/>
-                Je hebt een overzicht van alle koppelingen in je mailinglijst aangevraagd. Let op: Alle leden kunnen dit zien op hun wenslijst pagina.<br/>
+                Je hebt een overzicht van alle koppelingen in je mailinglijst aangevraagd. Let op: Alle leden kunnen dit zien op hun verlanglijst pagina.<br/>
                 <br/>
                 Hier volgt het overzicht van welke leden een cadeau zouden moeten voorzien voor welke leden.<br/>
             txt: >
                 Beste %owner%,
 
-                Je hebt een overzicht van alle koppelingen in je mailinglijst aangevraagd. Let op: Alle leden kunnen dit zien op hun wenslijst pagina.
+                Je hebt een overzicht van alle koppelingen in je mailinglijst aangevraagd. Let op: Alle leden kunnen dit zien op hun verlanglijst pagina.
 
                 Hier volgt het overzicht van welke leden een cadeau zouden moeten voorzien voor welke leden.
     poke_buddy:
@@ -385,6 +402,21 @@ emails:
                 <br/>
                 Klik op de onderstaande link en beheer jouw feestje.
         btn_poolstatus: Beheer jouw feestje
+    admin_wishlists:
+        subject: Secret Santa Mailinglijst verlanglijsten
+        message:
+            html: >
+                Beste %owner%,<br/>
+                <br/>
+                Je hebt een overzicht van alle verlanglijsten in je mailinglijst aangevraagd. Let op: Alle leden kunnen dit zien op hun verlanglijst pagina.<br/>
+                <br/>
+                Hier volgt een overzicht van elk lid en hun gewenste cadeautjes.
+            txt: >
+                Beste %owner%,
+
+                Je hebt een overzicht van alle verlanglijsten in je mailinglijst aangevraagd. Let op: Alle leden kunnen dit zien op hun verlanglijst pagina.
+
+                Hier volgt een overzicht van elk lid en hun gewenste cadeautjes.
     forgot_link:
         text: 'Hallo, <br /><br />U heeft ons gevraagd om de activatie mail met de link(s) naar de beheerpagina opnieuw te verzenden<br />'
         subject: 'Activatie mail opnieuw verzenden'
@@ -399,7 +431,10 @@ flashes:
         not_deleted: <h4>Niet verwijderd</h4> De bevestiging verliep foutief.
     expose:
         not_exposed: <h4>Mailinglijst niet gestuurd</h4> De bevestiging verliep foutief.
-        exposed: <h4>Mailinglijst gestuurd</h4> Alle gebruikers worden op de hoogte gebracht wanneer zij hun wenslijst bekijken.
+        exposed: <h4>Mailinglijst gestuurd</h4> Alle gebruikers worden op de hoogte gebracht wanneer zij hun verlanglijst bekijken.
+    expose_wishlists:
+        not_exposed: <h4>Verlanglijsten niet gestuurd</h4> De bevestiging verliep foutief.
+        exposed: <h4>Verlanglijsten gestuurd</h4> Alle gebruikers worden op de hoogte gebracht wanneer zij hun verlanglijst bekijken.
     resend:
         resent: <strong>Opnieuw verstuurd!</strong><br/>De e-mail aan %email% werd opnieuw verstuurd.<br/>
     entry:

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/admin_wishlists.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/admin_wishlists.html.twig
@@ -1,0 +1,39 @@
+{% extends 'IntractoSecretSantaBundle:Emails:basemail.html.twig' %}
+{% block main %}
+    <table width="640" border="0" cellpadding="0" cellspacing="0" align="center" style="font-family: Arial, Helvetica, sans-serif; font-size: 15px; color:#333333; line-height: 25px;">
+        <tr>
+            <td width="37" align="left">
+                <img src="http://www.eproof.be/assets/intracto/secret-santa/x.gif" width="37" style="display:block;" border="0" />
+            </td>
+            <td width="566">
+                <p>{{ 'emails.admin_wishlists.message.html'|trans({'%owner%': pool.ownername()})|raw }}</p>
+                {% for entry in pool.entries %}
+                    <table cellspacing="0" cellpadding="3" style="font-family: Arial, Helvetica, sans-serif; font-size: 15px; color:#333333; line-height: 25px;">
+                        <tr>
+                            <th style="border-bottom: 1px solid #000; text-align: left;"><strong>{{ 'label.name'|trans }}</strong></th>
+                            <th style="border-bottom: 1px solid #000;">&nbsp;</th>
+                            <th style="border-bottom: 1px solid #000; text-align: left;"><strong>{{ 'label.items'|trans }}</strong></th>
+                        </tr>
+                        <tr>
+                            <td valign="top">{{ entry.name }}</td>
+                            <td>&nbsp;</td>
+                            <td>
+                                {% if entry.wishlistitems|length > 0 %}
+                                    {% for item in entry.wishlistitems %}
+                                        {{ item.description|escape|linkify|raw }}<br>
+                                    {% endfor %}
+                                {% else %}
+                                    --
+                                {% endif %}
+                            </td>
+                        </tr>
+
+                    </table>
+                {% endfor %}
+            </td>
+            <td width="37" align="right">
+                <img src="http://www.eproof.be/assets/intracto/secret-santa/x.gif" width="37" style="display:block;" border="0" />
+            </td>
+        </tr>
+    </table>
+{% endblock %}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/admin_wishlists.txt.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/admin_wishlists.txt.twig
@@ -1,0 +1,8 @@
+{{ "emails.admin_wishlists.message.txt"|trans({"%owner%": pool.ownername()})|raw }}
+
+{{ "label.name"|trans }} >> {{ "label.items"|trans }}
+{% for entry in pool.entries %}
+    {{ entry.name }} >> {% if entry.wishlistitems|length > 0 %}{% for item in entry.wishlistitems %}{{ item.description|escape|linkify|raw }} | {% endfor %}{% else %}--{% endif %}
+{% endfor %}
+
+{{ 'emails.base.created_by'|trans }} http://www.intracto.com

--- a/src/Intracto/SecretSantaBundle/Resources/views/Entry/index.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Entry/index.html.twig
@@ -16,6 +16,11 @@
                 {% else %}
                     <i class="icon-eye-close" data-toggle="tooltip" data-placement="bottom" title="{{ 'entry.headers.not_exposed'|trans }}"></i>
                 {% endif %}
+                {% if entry.pool.wishlistsExposed %}
+                    <i class="icon-eye-open" data-toggle="tooltip" data-placement="bottom" title="{{ 'entry.headers.wishlists_exposed'|trans }}"></i>
+                {% else %}
+                    <i class="icon-eye-close" data-toggle="tooltip" data-placement="bottom" title="{{ 'entry.headers.wishlists_not_exposed'|trans }}"></i>
+                {% endif %}
             </li>
         </ul>
     </div>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Pool/manage.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Pool/manage.html.twig
@@ -54,6 +54,7 @@
 
         <button id="btn_delete" class="btn btn-primary"><i class="icon-warning-sign icon-white"></i> {{ 'btn.delete_list'|trans }}</button>
         <button id="btn_expose" class="btn btn-warning"><i class="icon-eye-open icon-white"></i> {{ 'btn.expose'|trans }}</button>
+        <button id="btn_expose_wishlists" class="btn btn-warning">{{ 'btn.expose_wishlists'|trans }}</button>
         <a class="btn btn-info" href="{{ path('pool_update', { 'listUrl': pool.listurl }) }}">{{ 'btn.pool_update'|trans|raw }}</a>
 
         <br/><br/>
@@ -91,6 +92,23 @@
                 <button type="reset" class="btn btn-warning" id="btn_expose_cancel">{{ 'btn.cancel'|trans }}</button>
             </form>
         </div>
+
+        <div id="expose-wishlists-warning" class="alert alert-warning" style="display:none;">
+            <h3>{{ 'expose_wishlists.title'|trans }}</h3>
+
+            {% set phraseToType = 'expose_wishlists.phrase_to_type'|trans %}
+            {{ 'expose_wishlists.body'|trans({ '%phrase_to_type%': phraseToType})|raw }}
+
+            <form action="{{ path('pool_expose_wishlists', { 'listUrl':pool.listUrl }) }}" method="post">
+                <input type="hidden" name="csrf_token" value="{{ expose_pool_wishlists_csrf_token }}">
+                <input type="text" name="confirmation" id="expose-wishlists-confirmation" autocomplete="off"
+                        onkeyup="if ($(this).val() == '{{ phraseToType }}') $('#btn_expose_wishlists_confirmation').removeAttr('disabled');"><br>
+                <button class="btn btn-warning" type="submit" id="btn_expose_wishlists_confirmation" disabled>
+                    {{ 'btn.expose_wishlists_confirm'|trans }}
+                </button>
+                <button type="reset" class="btn btn-warning" id="btn_expose_wishlists_cancel">{{ 'btn.cancel'|trans }}</button>
+            </form>
+        </div>
     </div>
 {% endblock %}
 
@@ -117,6 +135,17 @@
             $('#btn_expose_cancel').click(function(e) {
                 $('#expose-warning').hide();
                 $('#btn_expose').show().focus();
+            });
+
+            $('#btn_expose_wishlists').click(function(e) {
+                $('#expose-wishlists-warning').show();
+                $('#btn_expose_wishlists').hide();
+                $('#expose-wishlists-confirmation').focus();
+            });
+
+            $('#btn_expose_wishlists_cancel').click(function(e) {
+                $('#expose-wishlists-warning').hide();
+                $('#btn_expose_wishlists').show().focus();
             });
         });
 

--- a/src/Intracto/SecretSantaBundle/Resources/views/Pool/manage.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Pool/manage.html.twig
@@ -104,7 +104,7 @@
                 <input type="text" name="confirmation" id="expose-wishlists-confirmation" autocomplete="off"
                         onkeyup="if ($(this).val() == '{{ phraseToType }}') $('#btn_expose_wishlists_confirmation').removeAttr('disabled');"><br>
                 <button class="btn btn-warning" type="submit" id="btn_expose_wishlists_confirmation" disabled>
-                    {{ 'btn.expose_wishlists_confirm'|trans }}
+                    {{ 'btn.expose_wishlists_confirm'|trans|raw }}
                 </button>
                 <button type="reset" class="btn btn-warning" id="btn_expose_wishlists_cancel">{{ 'btn.cancel'|trans }}</button>
             </form>


### PR DESCRIPTION
Subissue of #37 & #93 

Similar to requesting the Secret Santa pairs, the admin can request an email with the wishlist of every single member in his pool.