### PR TITLE
Send event to dispatch pool mails (even if only 3 participants)

### DIFF
--- a/src/Intracto/SecretSantaBundle/Controller/PoolController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/PoolController.php
@@ -203,6 +203,11 @@ class PoolController extends Controller
         $this->getPool($listUrl);
 
         if ($this->pool->getCreated()) {
+            $this->eventDispatcher->dispatch(
+                PoolEvents::NEW_POOL_CREATED,
+                new PoolEvent($this->pool)
+            );
+            
             return $this->redirect($this->generateUrl('pool_created', ['listUrl' => $this->pool->getListurl()]));
         }
 


### PR DESCRIPTION
Bug introduced in #124, always dispatch event so mails are send to people (currenty pools of 3 people don't receive mails)