### PR TITLE
Catch exceptions in mail command and flush the status for send mails

### DIFF
--- a/src/Intracto/SecretSantaBundle/Command/SendEmptyWishlistReminderCommand.php
+++ b/src/Intracto/SecretSantaBundle/Command/SendEmptyWishlistReminderCommand.php
@@ -38,17 +38,21 @@ class SendEmptyWishlistReminderCommand extends ContainerAwareCommand
         $emptyWishlists = $entryMailQuery->findAllToRemindOfEmptyWishlist();
         $timeNow = new \DateTime();
 
-        foreach ($emptyWishlists as $entry) {
-            $itemCount = $wishlistMailQuery->countWishlistItemsOfParticipant($entry);
+        try {
+            foreach ($emptyWishlists as $entry) {
+                $itemCount = $wishlistMailQuery->countWishlistItemsOfParticipant($entry);
 
-            if ($itemCount[0]['wishlistItemCount'] == 0) {
-                $mailerService->sendWishlistReminderMail($entry);
-
-                $entry->setEmptyWishlistReminderSentTime($timeNow);
-                $em->persist($entry);
+                if ($itemCount[0]['wishlistItemCount'] == 0) {
+                    $mailerService->sendWishlistReminderMail($entry);
+    
+                    $entry->setEmptyWishlistReminderSentTime($timeNow);
+                    $em->persist($entry);
+                }
             }
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            $em->flush();
         }
-
-        $em->flush();
     }
 }

--- a/src/Intracto/SecretSantaBundle/Command/SendEntryViewReminderCommand.php
+++ b/src/Intracto/SecretSantaBundle/Command/SendEntryViewReminderCommand.php
@@ -37,13 +37,19 @@ class SendEntryViewReminderCommand extends ContainerAwareCommand
         $needsViewReminder = $entryMailQuery->findAllToRemindToViewEntry();
         $timeNow = new \DateTime();
 
-        foreach ($needsViewReminder as $entry) {
-            $mailerService->sendEntryViewReminderMail($entry);
+        try {
+            foreach ($needsViewReminder as $entry) {
+                $mailerService->sendEntryViewReminderMail($entry);
+    
+                $entry->setViewReminderSentTime($timeNow);
+                $em->persist($entry);
+            }
 
-            $entry->setViewReminderSentTime($timeNow);
-            $em->persist($entry);
+            $em->flush();
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            $em->flush();
         }
-
-        $em->flush();
     }
 }

--- a/src/Intracto/SecretSantaBundle/Query/EntryMailQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/EntryMailQuery.php
@@ -3,6 +3,7 @@
 namespace Intracto\SecretSantaBundle\Query;
 
 use Doctrine\ORM\EntityManager;
+use Intracto\SecretSantaBundle\Entity\Entry;
 
 class EntryMailQuery
 {
@@ -21,7 +22,7 @@ class EntryMailQuery
      * Find all entries that have an empty wishlist in Pools which were sent out
      * more than two weeks ago and the party date is max six weeks in the future.
      *
-     * @return array
+     * @return Entry[]|array
      */
     public function findAllToRemindOfEmptyWishlist()
     {
@@ -58,7 +59,7 @@ class EntryMailQuery
      * out more than two weeks ago and the party date is max six weeks in the
      * future.
      *
-     * @return array
+     * @return Entry[]|array
      */
     public function findAllToRemindToViewEntry()
     {


### PR DESCRIPTION
Currently when the cli command sends batch mails the send status is flushed at the end of the loop. When an exception occurs the status is not saved