### PR TITLE
Wishlist/Matched exposed indicator is wrong

### DIFF
--- a/src/Intracto/SecretSantaBundle/Resources/views/Entry/index.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Entry/index.html.twig
@@ -11,12 +11,12 @@
             <li><strong>{{ 'entry.headers.amount'|trans }} </strong> {{ entry.pool.amount }}</li>
             <li><strong>{{ 'entry.headers.num_people'|trans }} </strong> {{ entry.pool.entries|length }}</li>
             <li><strong>{{ 'entry.headers.person_created_list'|trans }} </strong> {{ entry.pool.entries|first.email }}
-                {% if entry.pool.exposed %}
+                {% if entry.pool.exposed == false %}
                     <i class="fa fa-eye-slash" data-toggle="tooltip" data-placement="bottom" title="{{ 'entry.headers.not_exposed'|trans }}"></i>
                 {% else %}
                     <i class="fa fa-eye" data-toggle="tooltip" data-placement="bottom" title="{{ 'entry.headers.exposed'|trans }}"></i>
                 {% endif %}
-                {% if entry.pool.wishlistsExposed %}
+                {% if entry.pool.wishlistsExposed == false %}
                     <i class="fa fa-eye-slash" data-toggle="tooltip" data-placement="bottom" title="{{ 'entry.headers.wishlists_not_exposed'|trans }}"></i>
                 {% else %}
                     <i class="fa fa-eye" data-toggle="tooltip" data-placement="bottom" title="{{ 'entry.headers.wishlists_exposed'|trans }}"></i>


### PR DESCRIPTION
Interface showed that wishlist/matches were exposed to the creator but it was not (reported in support mail). Bug introduced in a8e9268421cbd270384de981c2b0406524501c81

