### PR TITLE
Insights needs a DB to find this version and can't

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -43,6 +43,7 @@ assetic:
 # Doctrine Configuration
 doctrine:
     dbal:
+        server_version: 5.6
         driver:   "%database_driver%"
         host:     "%database_host%"
         port:     "%database_port%"


### PR DESCRIPTION
https://insight.sensiolabs.com/projects/5e845a60-cf8f-4e83-97d3-ecacb19cd091/analyses/51?status=violations#413777285

this is because of doctrine 2.5 see http://blog.insight.sensiolabs.com/2014/12/22/making-symfony-bootable-with-dbal-2-5.html

this is the suggested fix. Please OK and merge