### PR TITLE
[WIP] Replace genemu/form-bundle with custom datetype. Fixes #188

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -17,7 +17,6 @@ class AppKernel extends Kernel
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new Intracto\SecretSantaBundle\IntractoSecretSantaBundle(),
-            new Genemu\Bundle\FormBundle\GenemuFormBundle(),
             new JMS\I18nRoutingBundle\JMSI18nRoutingBundle(),
         );
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -71,9 +71,6 @@ jms_i18n_routing:
     locales: %supported_locales%
     strategy: prefix_except_default
 
-genemu_form:
-    date: ~
-
 services:
     twig.text_extension:
         class: Twig_Extensions_Extension_Text

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "sensio/framework-extra-bundle": "^3.0.2",
         "sensio/generator-bundle": "2.3.*",
         "incenteev/composer-parameter-handler": "~2.0",
-        "genemu/form-bundle": "^2.3",
         "jms/i18n-routing-bundle": "^2.0",
         "egulias/email-validator": "~1.2",
         "google/apiclient": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "83672a585b33205b10d5feac1a43315b",
+    "content-hash": "b083d85cd329c07faaf5bc5e34a5edb1",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -826,77 +826,6 @@
                 "validator"
             ],
             "time": "2017-02-03T22:48:59+00:00"
-        },
-        {
-            "name": "genemu/form-bundle",
-            "version": "v2.3.0",
-            "target-dir": "Genemu/Bundle/FormBundle",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/genemu/GenemuFormBundle.git",
-                "reference": "1bcc635d7604a409fbce569af709ea691d60b8e1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/genemu/GenemuFormBundle/zipball/1bcc635d7604a409fbce569af709ea691d60b8e1",
-                "reference": "1bcc635d7604a409fbce569af709ea691d60b8e1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2",
-                "symfony/form": "~2.6",
-                "symfony/framework-bundle": "~2.6",
-                "twig/twig": "~1.14"
-            },
-            "require-dev": {
-                "doctrine/doctrine-bundle": "1.*",
-                "doctrine/mongodb-odm-bundle": "*",
-                "doctrine/orm": "2.*",
-                "propel/propel-bundle": "*",
-                "symfony/doctrine-bridge": "~2.6",
-                "symfony/finder": "2.*"
-            },
-            "suggest": {
-                "doctrine/doctrine-bundle": "In order to use some form types with Doctrine",
-                "doctrine/mongodb-odm-bundle": "For MongoDB integration",
-                "symfony/finder": "For an image type",
-                "symfony/twig-bridge": "For integration into Twig templates"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Genemu\\Bundle\\FormBundle": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Olivier Chauvel",
-                    "email": "olivier@generation-multiple.com"
-                },
-                {
-                    "name": "Community contributions",
-                    "homepage": "https://github.com/genemu/GenemuFormBundle/contributors"
-                },
-                {
-                    "name": "Bilal Amarni",
-                    "email": "bilal.amarni@gmail.com"
-                }
-            ],
-            "description": "Extra form types for your Symfony2 projects",
-            "keywords": [
-                "extra form",
-                "form"
-            ],
-            "time": "2016-01-27T16:52:41+00:00"
         },
         {
             "name": "google/apiclient",

--- a/src/Intracto/SecretSantaBundle/DependencyInjection/Compiler/FormCompilerPass.php
+++ b/src/Intracto/SecretSantaBundle/DependencyInjection/Compiler/FormCompilerPass.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Intracto\SecretSantaBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * FormCompilerPass
+ *
+ * Adds new twig.form.resources
+ */
+class FormCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @var array
+     */
+    private $templates = ['jquery'];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $resources = $container->getParameter('twig.form.resources');
+
+        foreach ($this->templates as $template) {
+            $resources[] = 'IntractoSecretSantaBundle:Form:' . $template . '_layout.html.twig';
+        }
+
+        $container->setParameter('twig.form.resources', $resources);
+    }
+}

--- a/src/Intracto/SecretSantaBundle/Features/Context/Bootstrap/PoolContext.php
+++ b/src/Intracto/SecretSantaBundle/Features/Context/Bootstrap/PoolContext.php
@@ -100,7 +100,7 @@ class PoolContext extends MinkContext
         $currentDate = new \DateTime();
         $eventDate = $currentDate->add(new \DateInterval('P2M'));
 
-        $this->eventDate = $eventDate->format('d-m-y');
+        $this->eventDate = $eventDate->format('d-m-Y');
     }
 
     /**

--- a/src/Intracto/SecretSantaBundle/Form/Extension/DateTypeExtension.php
+++ b/src/Intracto/SecretSantaBundle/Form/Extension/DateTypeExtension.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Intracto\SecretSantaBundle\Form\Extension;
+
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+
+class DateTypeExtension extends AbstractTypeExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'widget' => 'single_text',
+            'format' => 'dd-mm-yyyy',
+            'append' => '<i class="icon-calendar"></i>',
+            'start_date' => 'today',
+            'end_date' => '31/12/2100',
+            'highlight_currentdate' => true,
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        // Adds a custom block prefix
+        array_splice(
+            $view->vars['block_prefixes'],
+            array_search('date', $view->vars['block_prefixes']),
+            0,
+            'intracto_secret_santa_jquerydatepicker'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function finishView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['type'] = 'text';
+
+        $view->vars = array_replace($view->vars, array(
+            'format' => $options['format'],
+            'start_date' => $options['start_date'],
+            'end_date' => $options['end_date'],
+            'highlight_currentdate' => $options['highlight_currentdate'],
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedType()
+    {
+        return DateType::class;
+    }
+}

--- a/src/Intracto/SecretSantaBundle/Form/PoolType.php
+++ b/src/Intracto/SecretSantaBundle/Form/PoolType.php
@@ -2,10 +2,10 @@
 
 namespace Intracto\SecretSantaBundle\Form;
 
-use Genemu\Bundle\FormBundle\Form\JQuery\Type\DateType;
 use Intracto\SecretSantaBundle\Entity\Pool;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -24,12 +24,7 @@ class PoolType extends AbstractType
                 'by_reference' => false,
             ])
             ->add('eventdate', DateType::class, [
-                'widget' => 'single_text',
                 'label' => 'form-pool.label.date_party',
-                'format' => 'dd-MM-yyyy',
-                'configs' => [
-                    'minDate' => 0,
-                ],
             ])
             ->add('amount', TextType::class, [
                 'label' => 'form-pool.label.amount_to_spend',

--- a/src/Intracto/SecretSantaBundle/Form/UpdatePoolDetailsType.php
+++ b/src/Intracto/SecretSantaBundle/Form/UpdatePoolDetailsType.php
@@ -2,9 +2,9 @@
 
 namespace Intracto\SecretSantaBundle\Form;
 
-use Genemu\Bundle\FormBundle\Form\JQuery\Type\DateType;
 use Intracto\SecretSantaBundle\Entity\Pool;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -15,12 +15,7 @@ class UpdatePoolDetailsType extends AbstractType
     {
         $builder
             ->add('eventdate', DateType::class, [
-                'widget' => 'single_text',
                 'label' => 'form-pool.label.date_party',
-                'format' => 'dd-MM-yyyy',
-                'configs' => [
-                    'minDate' => 0,
-                ],
             ])
             ->add('amount', TextType::class, ['label' => 'form-pool.label.amount_to_spend'])
             ->add('location', TextType::class, ['label' => 'form-pool.label.location'])

--- a/src/Intracto/SecretSantaBundle/IntractoSecretSantaBundle.php
+++ b/src/Intracto/SecretSantaBundle/IntractoSecretSantaBundle.php
@@ -2,8 +2,14 @@
 
 namespace Intracto\SecretSantaBundle;
 
+use Intracto\SecretSantaBundle\DependencyInjection\Compiler\FormCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class IntractoSecretSantaBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new FormCompilerPass());
+    }
 }

--- a/src/Intracto/SecretSantaBundle/Resources/config/services.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/services.xml
@@ -60,5 +60,14 @@
             <argument type="service" id="doctrine.orm.entity_manager" />
             <argument type="service" id="intracto_secret_santa.entry_shuffler" />
         </service>
+
+        <service id="intracto_secret_santa.twig.extension.form" class="Intracto\SecretSantaBundle\Twig\Extension\FormExtension">
+            <argument type="service" id="twig.form.renderer" />
+            <tag name="twig.extension" />
+        </service>
+
+        <service id="intracto_secret_santa.form.extension.jquery_date_type" class="Intracto\SecretSantaBundle\Form\Extension\DateTypeExtension">
+            <tag name="form.type_extension" extended_type="Symfony\Component\Form\Extension\Core\Type\DateType" />
+        </service>
     </services>
 </container>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Form/jquery_layout.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Form/jquery_layout.html.twig
@@ -1,0 +1,38 @@
+{% block form_javascript %}
+    {% spaceless %}
+        {% for child in form %}
+            {{ form_javascript(child) }}
+        {% endfor %}
+    {% endspaceless %}
+{% endblock form_javascript %}
+
+{% block intracto_secret_santa_jquerydatepicker_javascript %}
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.6.4/js/bootstrap-datepicker.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.6.4/locales/bootstrap-datepicker.fr.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.6.4/locales/bootstrap-datepicker.es.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.6.4/locales/bootstrap-datepicker.de.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.6.4/locales/bootstrap-datepicker.nl.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.6.4/locales/bootstrap-datepicker.no.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.6.4/locales/bootstrap-datepicker.pl.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.6.4/locales/bootstrap-datepicker.pt.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.6.4/locales/bootstrap-datepicker.ru.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.6.4/locales/bootstrap-datepicker.zh-CN.min.js"></script>
+    <script type="text/javascript">
+        jQuery(document).ready(function($) {
+            var field = $('#{{ id }}');
+            var locale = "{{ app.request.locale }}";
+
+            {% block intracto_secret_santa_jquerydatepicker_javascript_prototype %}
+            field.datepicker({
+                format: '{{ format }}',
+                autoclose: true,
+                forceParse: true,
+                startDate: "{{ start_date }}",
+                endDate: "{{ end_date }}",
+                todayHighlight: "{{ highlight_currentdate }}",
+                language: locale,
+            });
+            {% endblock %}
+        });
+    </script>
+{% endblock %}

--- a/src/Intracto/SecretSantaBundle/Resources/views/base.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/base.html.twig
@@ -29,6 +29,7 @@
     <link href="{{ asset_url }}" rel="stylesheet" media="screen"/>
     {% endstylesheets %}
     {% block stylesheets %}{% endblock %}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.6.4/css/bootstrap-datepicker3.min.css" />
     <style>
         table.entries input {
             margin-bottom: 0;

--- a/src/Intracto/SecretSantaBundle/Twig/Extension/FormExtension.php
+++ b/src/Intracto/SecretSantaBundle/Twig/Extension/FormExtension.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Intracto\SecretSantaBundle\Twig\Extension;
+
+use Symfony\Component\Form\FormView;
+use Symfony\Bridge\Twig\Form\TwigRendererInterface;
+
+class FormExtension extends \Twig_Extension
+{
+    /**
+     * This property is public so that it can be accessed directly from compiled
+     * templates without having to call a getter, which slightly decreases performance.
+     *
+     * @var \Symfony\Component\Form\FormRendererInterface
+     */
+    public $renderer;
+
+    /**
+     * @param TwigRendererInterface $renderer
+     */
+    public function __construct(TwigRendererInterface $renderer)
+    {
+        $this->renderer = $renderer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('form_javascript', array($this, 'renderJavascript'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('form_stylesheet', null, array(
+                'is_safe' => array('html'),
+                'node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode',
+            )),
+        );
+    }
+
+    /**
+     * Render Function Form Javascript
+     *
+     * @param FormView $view
+     * @param bool     $prototype
+     *
+     * @return string
+     */
+    public function renderJavascript(FormView $view, $prototype = false)
+    {
+        $block = $prototype ? 'javascript_prototype' : 'javascript';
+
+        return $this->renderer->searchAndRenderBlock($view, $block);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'intracto_secret_santa.twig.extension.form';
+    }
+}


### PR DESCRIPTION
This PR removes the genemu form bundle (as we only used the modified date type) and replaces the datetype with a custom version using [uxsolutions/bootstrap-datepicker](https://github.com/uxsolutions/bootstrap-datepicker).

TODO:

- [x] Test the implementation on local install (I had issues with the setup of vagrant. See [0e1f7fe](https://github.com/Intracto/SecretSanta/commit/0e1f7fe471b727fef68e9fc51c085631cc85da5e#commitcomment-21055424)

Note to self: Tag a new version of bootstrap-datepicker (1.7.0) and use this version instead of 1.6.4.