### PR TITLE
Fix #196 : Fix of datepicker issues

### DIFF
--- a/src/Intracto/SecretSantaBundle/Form/Extension/DateTypeExtension.php
+++ b/src/Intracto/SecretSantaBundle/Form/Extension/DateTypeExtension.php
@@ -17,10 +17,10 @@ class DateTypeExtension extends AbstractTypeExtension
     {
         $resolver->setDefaults(array(
             'widget' => 'single_text',
-            'format' => 'dd-mm-yyyy',
+            'format' => 'dd-MM-yyyy',
             'append' => '<i class="icon-calendar"></i>',
             'start_date' => 'today',
-            'end_date' => '31/12/2100',
+            'end_date' => '31-12-2100',
             'highlight_currentdate' => true,
         ));
     }

--- a/src/Intracto/SecretSantaBundle/Resources/views/Form/jquery_layout.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Form/jquery_layout.html.twig
@@ -31,6 +31,7 @@
                 endDate: "{{ end_date }}",
                 todayHighlight: "{{ highlight_currentdate }}",
                 language: locale,
+                disableTouchKeyboard: true,
             });
             {% endblock %}
         });


### PR DESCRIPTION
Touchboard is now disabled when using a mobile device and month is now corrected: month is now given in MM (full month) instead of mm (Numbers only).
Closes #196