### PR TITLE
Bug fix: Exports did not work due to undefined method

### DIFF
--- a/src/Intracto/SecretSantaBundle/Query/EntryReportQuery.php
+++ b/src/Intracto/SecretSantaBundle/Query/EntryReportQuery.php
@@ -376,9 +376,7 @@ class EntryReportQuery
 
     private function getPoolReuseBaseUrl()
     {
-        $router = $this->getContainer()->get('router');
-
-        $url = $router->generate(
+        $url = $this->router->generate(
             'pool_reuse',
             ['listUrl' => '1'],
             true


### PR DESCRIPTION
Query file already has router injected, but tried to load router with getContainer. This throws a undefined method error. See #205