### PR TITLE
Fix of Deprecations in PoolExcludeEntryType

### DIFF
--- a/src/Intracto/SecretSantaBundle/Controller/Pool/PoolController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Pool/PoolController.php
@@ -73,7 +73,7 @@ class PoolController extends Controller
             return $this->redirect($this->generateUrl('pool_created', ['listUrl' => $pool->getListurl()]));
         }
 
-        $form = $this->createForm(new PoolExcludeEntryType(), $pool);
+        $form = $this->createForm(PoolExcludeEntryType::class, $pool);
         if ('POST' === $request->getMethod()) {
             $form->handleRequest($request);
             if ($form->isValid()) {

--- a/src/Intracto/SecretSantaBundle/Form/Type/PoolExcludeEntryType.php
+++ b/src/Intracto/SecretSantaBundle/Form/Type/PoolExcludeEntryType.php
@@ -7,6 +7,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Valid;
 
 class PoolExcludeEntryType extends AbstractType
 {
@@ -29,7 +30,9 @@ class PoolExcludeEntryType extends AbstractType
             [
                 'data_class' => Pool::class,
                 'validation_groups' => ['exclude_entries'],
-                'cascade_validation' => true,
+                'constraints' => [
+                    new Valid(),
+                ],
             ]
         );
     }


### PR DESCRIPTION
Fix of 2 deprecations: Cascade_validation has been removed, constraints => valid should be used. And PoolExcludeEntryType is now called correctly in PoolController. (#193)