### PR TITLE
Fixed twig deprecations

### DIFF
--- a/src/Intracto/SecretSantaBundle/Twig/Extension/FormExtension.php
+++ b/src/Intracto/SecretSantaBundle/Twig/Extension/FormExtension.php
@@ -51,12 +51,4 @@ class FormExtension extends \Twig_Extension
 
         return $this->renderer->searchAndRenderBlock($view, $block);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'intracto_secret_santa.twig.extension.form';
-    }
 }

--- a/src/Intracto/SecretSantaBundle/Twig/LinkifyExtension.php
+++ b/src/Intracto/SecretSantaBundle/Twig/LinkifyExtension.php
@@ -24,9 +24,4 @@ class LinkifyExtension extends \Twig_Extension
             $html
         );
     }
-
-    public function getName()
-    {
-        return 'linkify_extension';
-    }
 }


### PR DESCRIPTION
[sensiolabs-de/deprecation-detector](https://github.com/sensiolabs-de/deprecation-detector) (goeie tip @rvanginneken) had nog 4 deprecations gevonden die nog in onze code zaten. Hierbij gefixt en we lijken dus klaar te zijn voor symfony 3 (tool is nog in alpha dus zou eventueel wel deprecations kunnen gemist hebben)

```
Finished searching for deprecations.

Rendering output...

+---+-------------------------------------------------------------------------------------------------+------+----------------------------------------------------------------+
| # | Usage                                                                                           | Line | Comment                                                        |
+---+-------------------------------------------------------------------------------------------------+------+----------------------------------------------------------------+
|   | /home/jeroen/projects/forks/SecretSanta/src/Intracto/SecretSantaBundle/Twig/Extension/FormExtension.php                                                                 |
+---+-------------------------------------------------------------------------------------------------+------+----------------------------------------------------------------+
| 1 | Overriding deprecated method Intracto\SecretSantaBundle\Twig\Extension\FormExtension->getName() | 58   | since 1.26 (to be removed in 2.0), not used anymore internally |
| 2 | Overriding deprecated method Intracto\SecretSantaBundle\Twig\Extension\FormExtension->getName() | 58   | since 1.26 (to be removed in 2.0), not used anymore internally |
+---+-------------------------------------------------------------------------------------------------+------+----------------------------------------------------------------+
|   | /home/jeroen/projects/forks/SecretSanta/src/Intracto/SecretSantaBundle/Twig/LinkifyExtension.php                                                                        |
+---+-------------------------------------------------------------------------------------------------+------+----------------------------------------------------------------+
| 3 | Overriding deprecated method Intracto\SecretSantaBundle\Twig\LinkifyExtension->getName()        | 28   | since 1.26 (to be removed in 2.0), not used anymore internally |
| 4 | Overriding deprecated method Intracto\SecretSantaBundle\Twig\LinkifyExtension->getName()        | 28   | since 1.26 (to be removed in 2.0), not used anymore internally |
+---+-------------------------------------------------------------------------------------------------+------+----------------------------------------------------------------+

```