### PR TITLE
Parties don't start automaticly anymore

### DIFF
--- a/src/Intracto/SecretSantaBundle/Controller/Party/ManagementController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Party/ManagementController.php
@@ -23,23 +23,7 @@ class ManagementController extends Controller
     public function validAction(Request $request, $listUrl)
     {
         /** @var \Intracto\SecretSantaBundle\Entity\Party $party */
-        $party = $this->get('intracto_secret_santa.repository.party')->findOneByListurl($listUrl);
-        if ($party === null) {
-            throw new NotFoundHttpException();
-        }
-
-        if (!$party->getCreated()) {
-            return $this->redirect($this->generateUrl('party_exclude', ['listUrl' => $party->getListurl()]));
-        }
-
-        if ($party->getSentdate() === null) {
-            $this->get('session')->getFlashBag()->add(
-                'success',
-                $this->get('translator')->trans('flashes.management.email_validated')
-            );
-
-            $this->get('intracto_secret_santa.mailer')->sendSecretSantaMailsForParty($party);
-        }
+        $party = $this->getParty($listUrl);
 
         $addParticipantForm = $this->createForm(
             AddParticipantType::class,
@@ -85,11 +69,7 @@ class ManagementController extends Controller
     public function updateAction(Request $request, $listUrl)
     {
         /** @var \Intracto\SecretSantaBundle\Entity\Party $party */
-        $party = $this->get('intracto_secret_santa.repository.party')->findOneByListurl($listUrl);
-
-        if ($party === null) {
-            throw new NotFoundHttpException();
-        }
+        $party = $this->getParty($listUrl);
 
         $updatePartyDetailsForm = $this->createForm(UpdatePartyDetailsType::class, $party);
         $updatePartyDetailsForm->handleRequest($request);
@@ -123,11 +103,7 @@ class ManagementController extends Controller
     public function addParticipantAction(Request $request, $listUrl)
     {
         /** @var \Intracto\SecretSantaBundle\Entity\Party $party */
-        $party = $this->get('intracto_secret_santa.repository.party')->findOneByListurl($listUrl);
-
-        if ($party === null) {
-            throw new NotFoundHttpException();
-        }
+        $party = $this->getParty($listUrl);
 
         $newParticipant = new Participant();
         $addParticipantForm = $this->createForm(AddParticipantType::class, $newParticipant);

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.de.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.de.yml
@@ -80,18 +80,19 @@ pool-create:
         participants: Teilnehmer
 
 # Pool/exclude.html.twig
-pool-exclude:
+party_manage-exclude:
     title: Ausschlieβen
     description: Mit dieser Liste können Sie auch Kombinationen von Teilnehmern ausschließen. o können Sie zum Beispiel verhindern, dass Mitglieder derselben Familie Geschenke füreinander kaufen solle.
-
+#    information
     placeholder_exclude: Um den Teilnehmer auszuwählen, der ausgeschlossen werden soll, klicken Sie auf dessen Namen.
-
     btn:
-        create_event: Erstellen Sie Ihr Ereignis!
-
+#        start_party:
+        cancel: Stornieren
     label:
         name: Name
         exclude: Ausschließen
+    feedback:
+#        not_enough:
 
 # Pool/created.html.twig
 pool-created:
@@ -309,6 +310,8 @@ pool_manage_valid:
 #        pool_update: ?
 #        remove_participant_confirm: ?
 #        updated_party: ?
+#        start_party:
+#        start_party_with_excludes:
 
     label:
         name: Name
@@ -464,6 +467,9 @@ flashes:
 #            success: ?
 #            danger: ?
 #        updated_party:
+#            success: ?
+#            danger: ?
+#        start_party:
 #            success: ?
 #            danger: ?
 

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.de.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.de.yml
@@ -486,7 +486,8 @@ flashes:
     entry:
         wishlist_updated: <h4>Wunschzettel aktualisiert</h4>Wir haben unsere Wichtel losgeschickt, um Ihren Secret Santa über Ihre Wünsche zu informieren!
         edit_email: <h4>Nicht gespeichert</h4> Die E-Mail-Adresse ist fehlerhaft.
-        saved_email: <h4>Gespeichert</h4> Die neue E-Mail-Adresse wurde gespeichert. Wir versenden auch diese E-Mail erneut.
+#        updated_participant:
+#        updated_participant_resent:
 #        remove_participant:
 #            success: ?
 #            danger: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -637,7 +637,8 @@ flashes:
     entry:
         wishlist_updated: <h4>Wishlist updated</h4>We've sent out our gnomes to notify your Secret Santa about your wishes!
         edit_email: <h4>Not saved</h4> There is an error in the email address.
-        saved_email: <h4>Saved</h4> The new email address was saved. We also resent the e-mail.
+        updated_participant: <h4>Saved</h4> We have updated the details of the participant!
+        updated_participant_resent: <h4>Saved</h4> We have updated the details of the participant! Since you changed the email and the party has already started, we also resent the email to this participant.
         remove_participant:
             success: <h4>Removed!</h4> Participant succesfully removed.
             danger: <h4>Oops</h4> Can't delete this participant, your party needs at least 3 participants.

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -81,18 +81,19 @@ pool-create:
         participants: Participants
 
 # Pool/exclude.html.twig
-pool-exclude:
+party_manage-exclude:
     title: Exclude
     description: With this list you can optionally prevent some participants combinations. For example to prevent members of the same family have to buy gifts for each other.
-
+    information: When you use excludes it might be possible that some users can't be removed anymore from the party. You can still add participants, but you won't be able to change the excludes anymore.
     placeholder_exclude: Click and choose the participants you want to exclude
-
     btn:
-        create_event: Create your event!
-
+        start_party: Start your party!
+        cancel: Cancel
     label:
         name: Name
         exclude: Exclude
+    feedback:
+        not_enough: Your party needs at least 4 participants to use excludes!
 
 # Pool/created.html.twig
 pool-created:
@@ -403,6 +404,8 @@ pool_manage_valid:
         pool_update: Send party update to participants
         remove_participant_confirm: Remove this participant
         updated_party: Update your party details
+        start_party: Start your party
+        start_party_with_excludes: Start your party with excludes
 
     label:
         name: Name
@@ -617,6 +620,9 @@ flashes:
         updated_party:
             success: <h4>Updated!</h4> Your party details have been succesfully updated.
             danger: <h4>Oops</h4> An error has occured while updating your party. Please try again.
+        start_party:
+            success: We started your party, and we've sent out the mails!
+            danger: There was an error starting your party, please try again!
 
     # PoolController
     pool:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
@@ -547,7 +547,8 @@ flashes:
     entry:
         wishlist_updated: <h4>Lista de deseos actualizada</h4>¡Hemos enviado a nuestros gnomos para que notifiquen a tu Secret Santa tus deseos!
         edit_email: <h4>No guardado</h4> Hay un error en la dirección de correo electrónico.
-        saved_email: <h4>Guardado</h4> Se guardó la nueva dirección de correo electrónico. También reenviamos el correo electrónico.
+#        updated_participant:
+#        updated_participant_resent:
         remove_participant:
             success: <h4>¡Expulsado!</h4> Participante expulsado de éxito.
             danger: <h4>Oops</h4> No puedes expulsar este participante, tu fiesta necesita al menos 3 participantes.

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
@@ -78,18 +78,19 @@ pool-create:
         participants: Participantes
 
 # Pool/exclude.html.twig
-pool-exclude:
+party_manage-exclude:
     title: Excluye
     description: Con esta lista puedes evitar, opcionalmente, algunas combinaciones de participantes. Por ejemplo, evitar que miembros de la misma familia tengan que comprar regalos los unos para los otros.
-
+#    information:
     placeholder_exclude: Hacer clic y elegir los participantes que se quiere excluir
-
     btn:
-        create_event: ¡Crear tu evento!
-
+#        start_party:
+#        cancel:
     label:
         name: Nombre
         exclude: Excluir
+    feedback:
+#       not_enough:
 
 # Pool/created.html.twig
 pool-created:
@@ -327,6 +328,8 @@ pool_manage_valid:
         pool_update: Envia una actualizaci&oacute;n a los participantes
         remove_participant_confirm: Expulsar este participante
         updated_party: Adaptar los detalles de la fiesta
+#        start_party:
+#        start_party_with_excludes:
 
     label:
         name: Nombre
@@ -527,6 +530,9 @@ flashes:
         updated_party:
             success: <h4>¡Actualizado!</h4> Tu fiesta ha sido actualizado de éxito.
             danger: <h4>Oops</h4> Ha occurido un error al actualizar tu fiesta. Por favor, inténtalo otra vez.
+#        start_party:
+#            success: ?
+#            danger: ?
 
     # PoolController
     pool:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
@@ -67,18 +67,19 @@ pool-create:
         participants: Participants
 
 # Pool/exclude.html.twig
-pool-exclude:
+party_manage-exclude:
     title: Exclure
     description: Avec cette liste, vous pouvez éventuellement éviter certaines combinaisons entre les membres. Pour éviter par exemple que les membres d'une même famille achètent des cadeaux pour chacun.
-
+#    information:
     placeholder_exclude: Cliquez et sélectionnez les partipants que vous désirez exclure
-
     btn:
-        create_event: Créez votre événement
-
+#        start_party:
+#        cancel:
     label:
         name: Nom
         exclude: Exclure
+    feedback:
+#       not_enough:
 
 # Pool/created.html.twig
 pool-created:
@@ -352,6 +353,8 @@ pool_manage_valid:
         pool_update: Envoyer une mise &agrave; jour &agrave; tous les participants
         remove_participant_confirm: Supprimer ce participant
         updated_party: Mettre &agrave; jour les détails de ma f&ecirc;te
+#        start_party:
+#        start_party_with_excludes:
 
     label:
         name: Nom
@@ -539,6 +542,9 @@ flashes:
         updated_party:
             success: <h4>Mis &agrave; jour!</h4> Les détails ont été mis &agrave; jour avec succ&egrave;s.
             danger: <h4>Oups</h4> Une erreur s'est produite lors de la mise &agrave; jour de votre f&ecirc;te. Veuillez essayer à nouveau.
+#        start_party:
+#            success: ?
+#            danger: ?
 
     # PoolController
     pool:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
@@ -559,7 +559,8 @@ flashes:
     entry:
         wishlist_updated: <h4>Liste de souhaits mise à jour</h4>Nous avons envoyé nos gnomes afin qu'ils avertissent votre Père-Noël secret de vos souhaits !
         edit_email: <h4>Non enregistrée</h4> l'adresse e-mail comporte une erreur.
-        saved_email: <h4>Enregistrée</h4> La nouvelle adresse e-mail a été enregistrée. Nous avons également renvoyé l'e-mail.
+#        updated_participant:
+#        updated_participant_resent:
         remove_participant:
             success: <h4>Supprimé!</h4> Participant supprimé avec succès.
             danger: <h4>Oups</h4> Ce participant ne peut être supprimé, votre f&ecirc;te nécessite au moins 3 participants.

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -643,7 +643,8 @@ flashes:
     entry:
         wishlist_updated: <h4>Verlanglijst geüpdatet</h4>We hebben onze kaboutertjes op pad gestuurd om jouw Secret Santa te vertellen op welke cadeau's je vurig hoopt!
         edit_email: <h4>Niet bewaard</h4> Er is wat fout met het e-mailadres.
-        saved_email: <h4>Bewaard</h4> Het nieuwe e-mailadres werd bewaard. We hebben ook de e-mail opnieuw verstuurd.
+        updated_participant: <h4>Aangepast!</h4> We hebben de details van de gebruiker aangepast!
+        updated_participant_resent: <h4>Aangepast!</h4> We hebben de details van de gebruiker aangepast! Omdat je het email adres hebt aangepast, en het feestje al gestart is, hebben we de email naar deze persoon opnieuw verzonden.
         remove_participant:
             success: <h4>Verwijderd!</h4> Deelnemer succesvol verwijderd.
             danger: <h4>Oops</h4> Deze deelnemer kan niet verwijderd worden, jouw feestje heeft minstens 3 deelnemers nodig.

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -79,18 +79,19 @@ pool-create:
         participants: Deelnemers
 
 # Pool/exclude.html.twig
-pool-exclude:
+party_manage-exclude:
     title: Uitsluiten
     description: Via deze lijst kan je optioneel voorkomen dat bepaalde deelnemers elkaar toegewezen krijgen. Bijvoorbeeld om te vermijden dat leden van hetzelfde gezin voor elkaar geschenken moeten kopen.
-
+    information: Wanneer je gebruik maakt van excludes kan je geen gebruikers meer verwijderen van het feestje. Je kan nog steeds deelnemers toevoegen, maar je zal de excludes niet meer kunnen wijzigen.
     placeholder_exclude: Klik en kies de deelnemers die je wilt uitsluiten
-
     btn:
-        create_event: Maak je evenement aan!
-
+        start_party: Start je feestje!
+        cancel: Annuleren
     label:
         name: Naam
         exclude: Uitsluiten
+    feedback:
+        not_enough: Je feestje moet minimaal 4 deelnemers hebben voordat je excludes kan gebruiken!
 
 # Pool/created.html.twig
 pool-created:
@@ -403,6 +404,9 @@ pool_manage_valid:
         pool_update: Verstuur update naar alle deelnemers
         remove_participant_confirm: Verwijder deze deelnemer
         updated_party: Bewerk de details van dit feestje
+        start_party: Start je feestje
+        start_party_with_excludes: Start je feestje met excludes
+
 
     label:
         name: Naam
@@ -622,6 +626,9 @@ flashes:
         updated_party:
             success: <h4>Updated!</h4> De details van jouw feestje zijn succesvol opgeslagen.
             danger: <h4>Oops</h4> Er heeft zich een fout voorgedaan bij het bijwerken van jouw feestje. Probeer opnieuw, alsjeblieft.
+        start_party:
+            success: We hebben je feestje gestart, en de deelnemers op de hoogte gebracht via email!
+            danger: Er is een fout opgetreden tijdens het starten van je feestje, probeer alsjeblieft opnieuw!
 
     # PoolController
     pool:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.no.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.no.yml
@@ -615,7 +615,8 @@ flashes:
     entry:
         wishlist_updated: <h4>Ønskelisten er oppdatert</h4>Vi har sendt en smånisse med beskjed til julenissen din om at ønskene dine er endret!
         edit_email: <h4>Not saved</h4> There is an error in the email address.
-        saved_email: <h4>Lagret</h4> Den nye epostadressen har blitt lagret. Vi har også sendt eposten på nytt.
+#        updated_participant:
+#        updated_participant_resent:
         remove_participant:
             success: <h4>Fjernet!</h4> Deltager er fjernet fra arrangemenet.
             danger: <h4>Oops</h4> Kan ikke slette denne deltageren, du trenger minst 3 deltagere.

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.no.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.no.yml
@@ -81,18 +81,19 @@ pool-create:
         participants: Deltagere
 
 # Pool/exclude.html.twig
-pool-exclude:
+party_manage-exclude:
     title: Eksluder kombinasjoner
     description: Med denne listen kan du helt valgfritt forhindre enkelte kombinasjoner av deltagerne. For eksempel kan du unngå at familiemedlemmer kjøper gaver til hverandre.
-
+#    information:
     placeholder_exclude: Klikk og velg deltagere du vil ekskludere fra listen
-
     btn:
-        create_event: Opprett arrangement!
-
+#        start_party:
+#        cancel:
     label:
         name: Navn
         exclude: Ekskluder
+    feedback:
+#       not_enough:
 
 # Pool/created.html.twig
 pool-created:
@@ -398,6 +399,8 @@ pool_manage_valid:
         pool_update: Send party update to participants
         remove_participant_confirm: Fjern denne deltageren
         updated_party: Oppdater detaljer for ditt arrangement
+#        start_party:
+#        start_party_with_excludes:
 
     label:
         name: Navn
@@ -595,6 +598,9 @@ flashes:
         updated_party:
             success: <h4>Oppdatert!</h4> Detaljene for ditt arrangement har blitt oppdatert(e)!
             danger: <h4>Oops</h4> En feil inntraff mens smånissene våre skulle oppdatere detaljene for arrangementet ditt. Vennligst prøv igjen.
+#        start_party:
+#            success: ?
+#            danger: ?
 
     # PoolController
     pool:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.pl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.pl.yml
@@ -70,18 +70,19 @@ pool-create:
         participants: Uczestników
 
 # Pool/exclude.html.twig
-pool-exclude:
+party_manage-exclude:
     title: Wyłącz
     description: Ta lista może potencjalnie wykluczyć pewne kombinacje uczestników. Na przykład uniemożliwić członkom tej samej rodziny wymianę prezentów między sobą.
-
+#    information:
     placeholder_exclude: Kliknij i wybierz uczestników, których chcesz wykluczyć
-
     btn:
-        create_event: Utwórz wydarzenie!
-
+#        start_party:
+#        cancel:
     label:
         name: Imię
         exclude: Wyłącz
+    feedback:
+#       not_enough:
 
 # Pool/created.html.twig
 pool-created:
@@ -271,6 +272,8 @@ pool_manage_valid:
 #        pool_update: ?
 #        remove_participant_confirm: ?
 #        updated_party: ?
+#        start_party:
+#        start_party_with_excludes:
 
     label:
         name: Imię
@@ -422,6 +425,9 @@ flashes:
 #            success: ?
 #            danger: ?
 #        updated_party:
+#            success: ?
+#            danger: ?
+#        start_party:
 #            success: ?
 #            danger: ?
 

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.pl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.pl.yml
@@ -444,7 +444,8 @@ flashes:
     entry:
         wishlist_updated: '<h4>Lista życzeń zaktualizowana</h4> Wysłaliśmy nasze skrzaty aby poinformowały Tajnego Mikołaja o twoich życzeniach!'
         edit_email: '<h4>Nie zapisano</h4> Występuje błąd w adresie email.'
-        saved_email: '<h4>Zapisano</h4> Nowy adres email został zapisany. Ponownie wysłaliśmy e-mail.'
+#        updated_participant:
+#        updated_participant_resent:
 #        remove_participant:
 #            success: ?
 #            danger: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.pt.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.pt.yml
@@ -74,18 +74,19 @@ pool-create:
         participants: Participantes
 
 # Pool/exclude.html.twig
-pool-exclude:
+party_manage-exclude:
     title: Excluir
     description: Com essa lista, você tem a opção de prevenir algumas combinações indesejadas. Por exemplo, para evitar que os membros de uma mesma família troque presentes apenas entre si.
-
+#    information:
     placeholder_exclude: Clique e escolha os participantes a excluir
-
     btn:
-        create_event: Criar um evento!
-
+#        start_party:
+#        cancel:
     label:
         name: Nome
         exclude: Excluir
+    feedback:
+#       not_enough:
 
 # Pool/created.html.twig
 pool-created:
@@ -367,6 +368,8 @@ pool_manage_valid:
 #        pool_update: ?
 #        remove_participant_confirm: ?
 #        updated_party: ?
+#        start_party:
+#        start_party_with_excludes:
 
     label:
         name: Nome
@@ -522,6 +525,9 @@ flashes:
 #            success: ?
 #            danger: ?
 #        updated_party:
+#            success: ?
+#            danger: ?
+#        start_party:
 #            success: ?
 #            danger: ?
 

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.pt.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.pt.yml
@@ -544,7 +544,8 @@ flashes:
     entry:
         wishlist_updated: <h4>Lista de desejos atualizada</h4> Mandamos os nossos elfos mágicos ir avisar quem te tirou de Amigo Secreto quais são os presentes super bacanas que você está esperando receber!
         edit_email: <h4>Não salvo</h4> Tem algo errado com o endereço e-mail.
-        saved_email: <h4>Salvo</h4> O novo endereço de e-mail foi salvo. Nós também enviamos o e-mail novamente.
+#        updated_participant:
+#        updated_participant_resent:
 #        remove_participant:
 #            success: ?
 #            danger: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.ru.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.ru.yml
@@ -486,7 +486,8 @@ flashes:
     entry:
         wishlist_updated: <h4>Список желаний обновлен</h4>Мы отправили наших гномов сообщить вашему Тайному Санте, что вы изменили список желаний!
         edit_email: <h4>Не сохранено</h4> Ошибка в написании электронного адреса.
-        saved_email: <h4>Сохранено</h4> Новый адрес электронной почты сохранен. Мы также повторно отправили письмо.
+#        updated_participant:
+#        updated_participant_resent:
 #        remove_participant:
 #            success: ?
 #            danger: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.ru.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.ru.yml
@@ -77,18 +77,19 @@ pool-create:
         participants: участников
 
 # Pool/exclude.html.twig
-pool-exclude:
+party_manage-exclude:
     title: Исключить:
     description: Список позволит вам на ваш выбор предотвратить нежелательные комбинации получателей и дарителей. Например, это поможет членам одной семьи не выбирать подарки друг для друга.
-
+#    information:
     placeholder_exclude: Кликните для выбора участников, которых вы хотели бы исключить
-
     btn:
-        create_event: Создать событие!
-
+#        start_party:
+#        cancel:
     label:
         name: Имя
         exclude: Исключить
+    feedback:
+#       not_enough:
 
 # Pool/created.html.twig
 pool-created:
@@ -309,6 +310,8 @@ pool_manage_valid:
 #        pool_update: ?
 #        remove_participant_confirm: ?
 #        updated_party: ?
+#        start_party:
+#        start_party_with_excludes:
 
     label:
         name: Имя
@@ -464,6 +467,9 @@ flashes:
 #            success: ?
 #            danger: ?
 #        updated_party:
+#            success: ?
+#            danger: ?
+#        start_party:
 #            success: ?
 #            danger: ?
 

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hans.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hans.yml
@@ -72,18 +72,19 @@ pool-create:
 #        participants: ?
 
 # Pool/exclude.html.twig
-pool-exclude:
+party_manage-exclude:
     title: 排除
     description: 在这名单里你可以随意防止一些参与人员的组合配对。例如防止同一家庭成员之间不得不买礼物给对方。
-
+#    information:
     placeholder_exclude: 点击选择你想要排除的参与人员
-
     btn:
-        create_event: 创建你的礼物交换活动！
-
+#        start_party:
+#        cancel:
     label:
         name: 名字
         exclude: 排除
+    feedback:
+#       not_enough:
 
 # Pool/created.html.twig
 pool-created:
@@ -304,6 +305,8 @@ pool_manage_valid:
 #        pool_update: ?
 #        remove_participant_confirm: ?
 #        updated_party: ?
+#        start_party:
+#        start_party_with_excludes:
 
     label:
         name: 名字
@@ -459,6 +462,9 @@ flashes:
 #            success: ?
 #            danger: ?
 #        updated_party:
+#            success: ?
+#            danger: ?
+#        start_party:
 #            success: ?
 #            danger: ?
 

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hans.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hans.yml
@@ -481,7 +481,8 @@ flashes:
     entry:
         wishlist_updated: <h4>愿望清单已更新</h4>We've sent out our gnomes to notify your Secret Santa about your wishes!
         edit_email: <h4>未保存</h4> 电子邮箱地址出错。
-        saved_email: <h4>已保存</h4> 已保存。新的电子邮箱地址已保存。我们也已重新发送电子邮件了。
+#        updated_participant:
+#        updated_participant_resent:
 #        remove_participant:
 #            success: ?
 #            danger: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hant.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hant.yml
@@ -481,7 +481,8 @@ flashes:
     entry:
         wishlist_updated: <h4>願望單已更新</h4>我們已送出我們的精靈去通知你的秘密聖誕老人關於你的願望!
         edit_email: <h4>並沒儲存</h4>這裡有電郵地址錯誤。
-        saved_email: <h4>儲存</h4> 新的電郵地址已儲存。我們亦重新傳送電郵。
+#        updated_participant:
+#        updated_participant_resent:
 #        remove_participant:
 #            success: ?
 #            danger: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hant.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hant.yml
@@ -72,18 +72,19 @@ pool-create:
 #        participants: ?
 
 # Pool/exclude.html.twig
-pool-exclude:
+party_manage-exclude:
     title: 排除
     description: 在這個目錄下，你好隨意阻止一些參與者組合。例如，防止來自同一家庭成員互相送禮物。
-
+#    information:
     placeholder_exclude: 點擊及選擇你想排除的參與者
-
     btn:
-        create_event: 創造你的項目!
-
+#        start_party:
+#        cancel:
     label:
         name: 名字
         exclude: 排除?
+    feedback:
+#       not_enough:
 
 # Pool/created.html.twig
 pool-created:
@@ -304,6 +305,8 @@ pool_manage_valid:
 #        pool_update: ?
 #        remove_participant_confirm: ?
 #        updated_party: ?
+#        start_party:
+#        start_party_with_excludes:
 
     label:
         name: 名字
@@ -459,6 +462,9 @@ flashes:
 #            success: ?
 #            danger: ?
 #        updated_party:
+#            success: ?
+#            danger: ?
+#        start_party:
 #            success: ?
 #            danger: ?
 

--- a/src/Intracto/SecretSantaBundle/Resources/views/Party/exclude.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Party/exclude.html.twig
@@ -17,9 +17,14 @@
 
 {% block main %}
     <div class="box">
-        <h1>{{ 'pool-exclude.title'|trans }}</h1>
+        <h1>{{ 'party_manage-exclude.title'|trans }}</h1>
 
-        <p>{{ 'pool-exclude.description'|trans }}</p>
+        <p>{{ 'party_manage-exclude.description'|trans }}</p>
+
+        <div class="alert alert-info" role="alert">
+            <i class="fa fa-info-circle"></i> {{ 'party_manage-exclude.information' | trans }}
+        </div>
+
         {{ form_start(form) }}
         {# Only show general validation error if there are no subform errors #}
         {% if form.participants.vars.valid %}
@@ -29,8 +34,8 @@
             <thead>
             <tr>
                 <th class="col-xs-1">#</th>
-                <th class="col-xs-3">{{ 'pool-exclude.label.name'|trans }}</th>
-                <th class="col-xs-8">{{ 'pool-exclude.label.exclude'|trans }}</th>
+                <th class="col-xs-3">{{ 'party_manage-exclude.label.name'|trans }}</th>
+                <th class="col-xs-8">{{ 'party_manage-exclude.label.exclude'|trans }}</th>
             </tr>
             </thead>
             <tbody>
@@ -39,7 +44,7 @@
                     <td class="entry-number">{{ loop.index }}</td>
                     <td>{{ entry.excluded_participants.vars.label }}</td>
                     <td>
-                        {{ form_widget(entry.excluded_participants, {'attr': {'placeholder': 'pool-exclude.placeholder_exclude'} } ) }}
+                        {{ form_widget(entry.excluded_participants, {'attr': {'placeholder': 'party_manage-exclude.placeholder_exclude'} } ) }}
                         {{ form_errors(entry.excluded_participants) }}
                     </td>
                 </tr>
@@ -47,8 +52,11 @@
             </tbody>
         </table>
         <p>
-            <button type="submit" class="btn btn-large btn-primary btn-create-event">
-                <i class="fa fa-check"></i> {{ 'pool-exclude.btn.create_event'|trans }}
+            <a href="{{ path('party_manage', {'listUrl' : party.listUrl}) }}" class="btn btn-large btn-danger btn-create-event">
+                {{ 'party_manage-exclude.btn.cancel'|trans }}
+            </a>
+            <button type="submit" class="btn btn-large btn-success btn-create-event">
+                <i class="fa fa-play"></i> {{ 'party_manage-exclude.btn.start_party'|trans }}
             </button>
         </p>
         {{ form_end(form) }}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
@@ -38,13 +38,15 @@
                              onclick="editableEmail('{{ party.listUrl }}', {{ participant.id }});"
                              rel="tooltip" title="{{ 'pool_manage_valid.manage.edit_email'|trans }}" alt="{{ 'pool_manage_valid.manage.edit_email'|trans }}"
                              style="cursor: pointer;">
-                        {% spaceless %}
-                            <a href="{{ path('resend_participant', { 'listUrl': party.listUrl, 'participantId': participant.id }) }}">
-                                <img src="{{ asset('bundles/intractosecretsanta/img/envelope.png') }}" rel="tooltip"
-                                     title="{{ 'pool_manage_valid.manage.resend_email'|trans }}" alt="{{ 'pool_manage_valid.manage.resend_email'|trans }}">
-                            </a>
-                        {% endspaceless %}
-                        {% if app.environment == 'dev' %}
+                        {% if party.created %}
+                            {% spaceless %}
+                                <a href="{{ path('resend_participant', { 'listUrl': party.listUrl, 'participantId': participant.id }) }}">
+                                    <img src="{{ asset('bundles/intractosecretsanta/img/envelope.png') }}" rel="tooltip"
+                                         title="{{ 'pool_manage_valid.manage.resend_email'|trans }}" alt="{{ 'pool_manage_valid.manage.resend_email'|trans }}">
+                                </a>
+                            {% endspaceless %}
+                        {% endif %}
+                        {% if app.environment == 'dev' and participant.assignedParticipant != null %}
                             <a href="{{ path('participant_view', { 'url': participant.url }) }}" class="add-participant-link">
                                 <img src="{{ asset('bundles/intractosecretsanta/img/view.png') }}" rel="tooltip"
                                      title="{{ participant.assignedParticipant.name }} <{{ participant.assignedParticipant.email }}>"
@@ -59,22 +61,23 @@
             {% endfor %}
             </tbody>
         </table>
-
         <div class="alert alert-info">
             <strong>{{ 'pool_manage_valid.manage.tip'|trans }}</strong> {{ 'pool_manage_valid.manage.come_back'|trans }}
         </div>
+        {% if not party.created  %}
+            <a href="{{ path('party_manage_start', { 'listUrl': party.listurl }) }}" class="btn btn-success manage_btn manage_btn_link">
+                <i class="fa fa-play"></i> {{ 'pool_manage_valid.btn.start_party'|trans }}
+            </a>
+            {% if party.participants | length >3 %}
+                <a href="{{ path('party_exclude', { 'listUrl': party.listurl }) }}" class="btn btn-success manage_btn manage_btn_link manage_btn_middle">
+                    <i class="fa fa-play"></i> {{ 'pool_manage_valid.btn.start_party_with_excludes'|trans }}
+                </a>
+            {% endif %}
+        {% endif %}
+        <div class="clearfix"></div>
         <button id="btn_delete" class="btn btn-primary manage_btn">
             <i class="fa fa-exclamation-circle"></i> {{ 'pool_manage_valid.btn.delete_list'|trans }}
         </button>
-        <a href="{{ path('expose_participants', { 'listUrl': party.listurl }) }}" class="btn btn-warning manage_btn manage_btn_middle manage_btn_link">
-            <i class="fa fa-eye"></i> {{ 'pool_manage_valid.btn.expose'|trans }}
-        </a>
-        <a id="btn_expose_wishlists" class="btn btn-warning manage_btn manage_btn_link" href="{{ path('wishlist_show_all', { 'listUrl': party.listurl }) }}">
-            <i class="fa fa-eye"></i> {{ 'pool_manage_valid.btn.expose_wishlists'|trans }}
-        </a>
-        <a class="btn btn-info manage_btn manage_btn_link" href="{{ path('send_party_update', { 'listUrl': party.listurl }) }}">
-            <i class="fa fa-envelope"></i> {{ 'pool_manage_valid.btn.pool_update'|trans|raw }}
-        </a>
         <button id="btn_add" class="btn btn-success manage_btn manage_btn_middle"
                 {% if (form_errors(addParticipantForm.name)) or (form_errors(addParticipantForm.email)) %}disabled{% endif %}>
             <i class="fa fa-plus-circle fa-inverse"></i> {{ 'pool_manage_valid.btn.add_participant'|trans|raw }}
@@ -82,7 +85,17 @@
         <button id="btn_update" class="btn btn-warning manage_btn">
             <i class="fa fa-refresh"></i> {{ 'pool_manage_valid.btn.updated_party'|trans|raw }}
         </button>
-
+        {% if party.created %}
+            <a class="btn btn-info manage_btn manage_btn_link" href="{{ path('send_party_update', { 'listUrl': party.listurl }) }}">
+                <i class="fa fa-envelope"></i> {{ 'pool_manage_valid.btn.pool_update'|trans|raw }}
+            </a>
+            <a href="{{ path('expose_participants', { 'listUrl': party.listurl }) }}" class="btn btn-warning manage_btn manage_btn_middle manage_btn_link">
+                <i class="fa fa-eye"></i> {{ 'pool_manage_valid.btn.expose'|trans }}
+            </a>
+            <a id="btn_expose_wishlists" class="btn btn-warning manage_btn manage_btn_link" href="{{ path('wishlist_show_all', { 'listUrl': party.listurl }) }}">
+                <i class="fa fa-eye"></i> {{ 'pool_manage_valid.btn.expose_wishlists'|trans }}
+            </a>
+        {% endif %}
         <br/><br/>
 
         <div id="delete-warning" class="alert alert-danger" style="display: none;">

--- a/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
@@ -13,6 +13,7 @@
 
 {% block main %}
     <div class="box">
+        <span id="alertspan"></span>
         <h1>{{ 'pool_manage_valid.manage.title'|trans }}</h1>
         <table class="table table-striped mysanta" id="mysanta">
             <thead>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
@@ -29,13 +29,13 @@
             {% for participant in party.participants %}
                 <tr class="entry {% if loop.index == 1 %}owner{% else %}not-owner{% endif %}">
                     <td class="entry-number">{{ loop.index }}</td>
-                    <td data-hj-masked>{{ participant.name }}</td>
+                    <td id="name_{{ participant.id }}" data-hj-masked>{{ participant.name }}</td>
                     <td id="email_{{ participant.id }}" data-hj-masked>{{ participant.email }}</td>
                     <td class="{% if participant.viewdate %}viewed">{{ 'pool_manage_valid.manage.yes'|trans }}{% else %}not_viewed">{{ 'pool_manage_valid.manage.not_yet'|trans }}{% endif %}</td>
                     <td class="{% if participant.wishlistItems is not empty %}viewed">{{ 'pool_manage_valid.manage.yes'|trans }}{% else %}not_viewed">{{ 'pool_manage_valid.manage.not_yet'|trans }}{% endif %}</td>
                     <td style="text-align: right;">
                         <img src="{{ asset('bundles/intractosecretsanta/img/edit.png') }}"
-                             onclick="editableEmail('{{ party.listUrl }}', {{ participant.id }});"
+                             onclick="editParticipant('{{ party.listUrl }}', {{ participant.id }});"
                              rel="tooltip" title="{{ 'pool_manage_valid.manage.edit_email'|trans }}" alt="{{ 'pool_manage_valid.manage.edit_email'|trans }}"
                              style="cursor: pointer;">
                         {% if party.created %}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.js.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.js.twig
@@ -52,19 +52,31 @@
         }
     });
 
-    function editableEmail(listUrl, entryId) {
+    function editParticipant(listUrl, entryId) {
         var email = $('#email_' + entryId).html();
-        var url = '{{ path("participant_email_edit", { 'listUrl': 'listUrl', 'participantId': 'entryId' }) }}';
+        var name = $('#name_' + entryId).html();
+        var url = '{{ path("participant_edit", { 'listUrl': 'listUrl', 'participantId': 'entryId' }) }}';
         url = url.replace("listUrl", listUrl);
         url = url.replace("entryId", entryId);
         if ($('#email_' + entryId).has('form').length == 0) {
+            $('#name_' + entryId).html(
+                '<input type="text" id="input_name_' + entryId + '" class="form-control input_edit_email" name="name" value="' + name + '" data-hj-masked>'
+            );
             $('#email_' + entryId).html(
-                '<form action="' + url + '" method="post">' +
-                '<input type="text" class="form-control input_edit_email" name="email" value="' + email + '" data-hj-masked>&nbsp;' +
-                '<button class="btn btn-small btn-primary" type="submit"><i class="fa fa-check"></i> {{ 'pool_manage_valid.manage.save'|trans }}</button>' +
+                '<form id ="form_' + entryId + '" action="' + url + '" method="post">' +
+                '<input type="text" id="input_email_' + entryId + '" class="form-control input_edit_email" name="email" value="' + email + '" data-hj-masked>&nbsp;' +
+                '<button class="btn btn-small btn-primary" onclick="submitEditForm(' + entryId + ')"><i class="fa fa-check"></i> {{ 'pool_manage_valid.manage.save'|trans }}</button>'+
                 '</form>'
             );
         }
+    }
+
+    function submitEditForm(entryId) {
+            $('#form_' + entryId).append($('#input_name_' + entryId));
+            $('#form_' + entryId).hide();
+            $('#name_' + entryId).html('<i class="fa fa-spinner fa-spin "></i>');
+            $(document.body).append($('#form_' + entryId));
+            $('#form_' + entryId).submit();
     }
 
     function attachAction(listUrl, entryId) {

--- a/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.js.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.js.twig
@@ -59,24 +59,51 @@
         url = url.replace("listUrl", listUrl);
         url = url.replace("entryId", entryId);
         if ($('#email_' + entryId).has('form').length == 0) {
-            $('#name_' + entryId).html(
-                '<input type="text" id="input_name_' + entryId + '" class="form-control input_edit_email" name="name" value="' + name + '" data-hj-masked>'
-            );
-            $('#email_' + entryId).html(
-                '<form id ="form_' + entryId + '" action="' + url + '" method="post">' +
-                '<input type="text" id="input_email_' + entryId + '" class="form-control input_edit_email" name="email" value="' + email + '" data-hj-masked>&nbsp;' +
-                '<button class="btn btn-small btn-primary" onclick="submitEditForm(' + entryId + ')"><i class="fa fa-check"></i> {{ 'pool_manage_valid.manage.save'|trans }}</button>'+
-                '</form>'
-            );
+            makeEditForm(entryId, listUrl, name, email);
         }
     }
 
-    function submitEditForm(entryId) {
-            $('#form_' + entryId).append($('#input_name_' + entryId));
-            $('#form_' + entryId).hide();
-            $('#name_' + entryId).html('<i class="fa fa-spinner fa-spin "></i>');
-            $(document.body).append($('#form_' + entryId));
-            $('#form_' + entryId).submit();
+    function submitEditForm(listUrl,participantId) {
+        var url = '{{ path("participant_edit") }}';
+        var name = $('#input_name_' + participantId).val();
+        var email = $('#input_email_' + participantId).val();
+        $('#input_name_' + participantId).prop('disabled', true);
+        $('#input_email_' + participantId).prop('disabled', true);
+        $('#submit_btn_' + participantId).prop('disabled', true);
+        $('#submit_btn_' + participantId).html('<i class="fa fa-spinner fa-spin"></i>');
+        $("#alertspan").html('');
+        var data = {
+            listUrl: listUrl,
+            participantId: participantId,
+            name: name,
+            email: email,
+        }
+        console.log(data);
+        $.ajax({
+            type: 'POST',
+            url: url,
+            data: data,
+        }).done(function( data ) {
+            console.log(data);
+            if(data.responseCode == 200){
+                $("#alertspan").html('<div class="alert alert-'+ data.message.type +'" role="alert">'+ data.message.message +'</div>');
+                $('#name_' + participantId).html(name);
+                $('#email_' + participantId).html(email);
+            } else {
+                $("#alertspan").html('<div class="alert alert-'+ data.message.type +'" role="alert">'+ data.message.message +'</div>');
+                makeEditForm(participantId, listUrl, name, email);
+            }
+        });
+    }
+
+    function makeEditForm(participantId, listUrl, name, email){
+        $('#name_' + participantId).html(
+            '<input type="text" id="input_name_' + participantId + '" class="form-control input_edit_email" name="name" value="' + name + '" data-hj-masked>'
+        );
+        $('#email_' + participantId).html(
+            '<input type="text" id="input_email_' + participantId + '" class="form-control input_edit_email" name="email" value="' + email + '" data-hj-masked>&nbsp;' +
+            '<button class="btn btn-small btn-primary" id="submit_btn_' + participantId + '" onclick="submitEditForm( \'' + listUrl + '\', ' + participantId + ')"><i class="fa fa-check"></i> {{ 'pool_manage_valid.manage.save'|trans }}</button>'
+        );
     }
 
     function attachAction(listUrl, entryId) {

--- a/src/Intracto/SecretSantaBundle/Validator/ParticipantHasValidExcludesValidator.php
+++ b/src/Intracto/SecretSantaBundle/Validator/ParticipantHasValidExcludesValidator.php
@@ -17,19 +17,17 @@ class ParticipantHasValidExcludesValidator extends ConstraintValidator
         $party = $participant->getParty();
         //should be at least 2 possible entries remaining to choose from, -1 for itself
         if ($party->getParticipants()->count() < $participant->getExcludedParticipants()->count() + 3) {
-            $this->context->addViolationAt(
-                'excluded_participants',
-                $constraint->messageNoUniqueMatch,
-                ['%name%' => $participant->getName()]
-            );
+            $this->context->buildViolation($constraint->messageNoUniqueMatch)
+                ->atPath('exclude_participants')
+                ->setParameter('%name%', $participant->getName())
+                ->addViolation();
         }
         //Should not be necessary but you never know eyy..
         if ($participant->getExcludedParticipants()->contains($participant)) {
-            $this->context->addViolationAt(
-                'excluded_participants',
-                '%name% can not exclude itself',
-                ['%name%' => $participant->getName()]
-            );
+            $this->context->buildViolation('%name% can not exclude itself')
+                ->atPath('exclude_participants')
+                ->setParameter('%name%', $participant->getName())
+                ->addViolation();
         }
     }
 }

--- a/src/Intracto/SecretSantaBundle/Validator/PartyHasValidExcludesValidator.php
+++ b/src/Intracto/SecretSantaBundle/Validator/PartyHasValidExcludesValidator.php
@@ -19,10 +19,9 @@ class PartyHasValidExcludesValidator extends ConstraintValidator
     public function validate($pool, Constraint $constraint)
     {
         if (!$this->participantShuffler->shuffleParticipants($pool)) {
-            $this->context->addViolationAt(
-                'entries',
-                $constraint->message
-            );
+            $this->context->buildViolation($constraint->message)
+                ->atPath('entries')
+                ->addViolation();
         }
     }
 }


### PR DESCRIPTION
Party doesn’t start automatically anymore when admin confirms email. Instead party is in a frozen state, no emails are sent and all changes are possible. When the admin decides to start the party, the participants are shuffled and the mails are sent out. When started with excludes, limited changes are possible. When started without, most changes are possible, but not encouraged. Workaround for #151 . 
It's now also possible to edit the name of a participant. To ensure correct form handling and increase ux (showing error's and possibility to edit) handling of this form is now done with ajax. See #166 
Closes #151 & #166