### PR TITLE
#250: Improved forgot email functionality 

### DIFF
--- a/src/Intracto/SecretSantaBundle/Controller/Party/ForgotManagementURLController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Party/ForgotManagementURLController.php
@@ -47,14 +47,14 @@ class ForgotManagementURLController extends Controller
 
         $form->handleRequest($request);
         if ($form->isValid()) {
-            if ($this->get('intracto_secret_santa.mailer')->sendForgotManageLinkMail($form->getData()['email'])) {
+            if ($this->get('intracto_secret_santa.mailer')->sendForgotLinkMail($form->getData()['email'])) {
                 $feedback = [
                     'type' => 'success',
                     'message' => $this->get('translator')->trans('flashes.forgot_management_url.success'),
                 ];
             } else {
                 $feedback = [
-                    'type' => 'error',
+                    'type' => 'danger',
                     'message' => $this->get('translator')->trans('flashes.forgot_management_url.error'),
                 ];
             }

--- a/src/Intracto/SecretSantaBundle/Entity/ParticipantRepository.php
+++ b/src/Intracto/SecretSantaBundle/Entity/ParticipantRepository.php
@@ -42,4 +42,30 @@ class ParticipantRepository extends EntityRepository
 
         return $query->getResult();
     }
+
+    /**
+     * Return all the participants, which are not admin, the event is in the future or past week, and participant is already assigned to a participant.
+     *
+     * @Param String $email
+     *
+     * @Return Participant[]
+     */
+    public function findAllParticipantsForForgotEmail($email)
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->addSelect('participant')
+            ->from('IntractoSecretSantaBundle:Participant', 'participant')
+            ->join('participant.party', 'party')
+            ->andWhere('participant.partyAdmin = false')
+            ->andWhere('participant.email = :email')
+            ->andWhere('party.eventdate >= :date')
+            ->andWhere('participant.url IS NOT NULL')
+            ->orderBy('party.eventdate', 'ASC')
+            ->setParameters([
+                'email' => $email,
+                'date' => new \DateTime('-1 week'),
+            ]);
+
+        return $qb->getQuery()->getResult();
+    }
 }

--- a/src/Intracto/SecretSantaBundle/Entity/PartyRepository.php
+++ b/src/Intracto/SecretSantaBundle/Entity/PartyRepository.php
@@ -12,11 +12,13 @@ class PartyRepository extends EntityRepository
         $qb->addSelect('party.listurl')
             ->addSelect('party.eventdate')
             ->addSelect('party.locale')
+            ->addSelect('party.location')
             ->from('IntractoSecretSantaBundle:Party', 'party')
             ->join('party.participants', 'participants')
             ->andWhere('participants.partyAdmin = true')
             ->andWhere('participants.email = :email')
             ->andWhere('party.eventdate >= :date')
+            ->orderBy('party.eventdate', 'ASC')
             ->setParameters([
                 'email' => $email,
                 'date' => new \DateTime('-1 week'),

--- a/src/Intracto/SecretSantaBundle/Form/Type/ForgotLinkType.php
+++ b/src/Intracto/SecretSantaBundle/Form/Type/ForgotLinkType.php
@@ -24,7 +24,7 @@ class ForgotLinkType extends AbstractType
             ])
             ->add('submit', SubmitType::class, [
                 'attr' => ['class' => 'btn btn-large btn-primary btn-create-event'],
-                'label' => 'pool_manage_valid.manage.resend_email',
+                'label' => 'party-forgot_link.submit_btn',
             ])
         ;
     }

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.de.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.de.yml
@@ -116,10 +116,11 @@ pool-deleted:
     body: <p>Vielen Dank, dass Sie den Secret Santa-Organizer benutzt haben. Wir hoffen, Sie nächstes Jahr wieder begrüßen zu dürfen!</p>
     create_new_list: Erstellen Sie eine neue Secret Santa-Liste!
 
-# Pool/forgotLink.html.twig
-#pool-forgot_link:
+# Party/forgotLink.html.twig
+#party-forgot_link:
 #    title: ?
 #    description: ?
+#    submit_btn: ?
 
 # Wishlist/showAll.html.twig
 #wishlist-show_all:
@@ -343,8 +344,17 @@ emails-emptyWishlistReminder:
 
 # Emails/forgotLink.{html,txt}.twig
 emails-forgot_link:
-    title: Ihre Secret Santa-Liste
-#    subject: ?
+#    subject:
+#    participating_in:
+#    created_these:
+#    table_labels:
+#        date:
+#        location:
+#        link:
+#        txt:
+#    btn:
+#        party_link:
+#        manage_link:
 #    message:
 #        html: ?
 #        txt: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -155,8 +155,9 @@ static-faq:
         <a name="manage"></a><h2>How do I manage my party / participants?</h2>
         <p>The confirmation e-mail sent to the list administrator contains a link to the list's management page.</p>
 
-        <a href="lost"></a><h2>I lost my activation mail.</h2>
-        <p>If you lost your activation e-mail (which contains the link to the admin page), fill in the list administrator e-mail address on <a href="http://www.secretsantaorganizer.com/forgot-link">this page</a> and we will send you the link again.</p>
+        <a href="lost"></a><h2>I lost my activation mail / url to the party.</h2>
+        <p>If you lost your e-mail (which contains the link to the admin page or to the party where you are participating in), fill in your e-mail address on <a href="http://www.secretsantaorganizer.com/forgot-link">this page</a> and we will send you
+        an overview of all the parties where you are participating in and/or the parties you have created.</p>
 
         <a name="changes"></a><h2>Can I add or remove people?</h2>
         <p>You can add or remove people after creating an event. On the admin page you will find a delete button and a form to add new people. There is only one catch: you can't do this if the admin excluded combinations before submitting the event.

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -118,9 +118,10 @@ pool-deleted:
     create_new_list: Create a new Secret Santa list!
 
 # Pool/forgotLink.html.twig
-pool-forgot_link:
-    title: 'Resend activation mail'
-    description: 'Fill in the email address of the pool owner and we will resend the activation email. It only works for pools which took place in the past week or will be held in the future. (This will only send the admin page link)'
+party-forgot_link:
+    title: 'Request overview of my parties'
+    description: 'Fill in your email address and we will sent you an email with all the parties you have created and the parties where you are participating in. We only list the parties taking place in the future.'
+    submit_btn: Send me an overview
 
 # Wishlist/showAll.html.twig
 wishlist-show_all:
@@ -437,14 +438,23 @@ emails-emptyWishlistReminder:
 
 # Emails/ForgotLink.{html,txt}.twig
 emails-forgot_link:
-    title: Your Secret Santa list
-    subject: Resend activation mail
+    subject: Overview of my parties
+    participating_in: You are participating in the following parties:
+    created_these: You've created these parties:
+    table_labels:
+        date: Date
+        location: Location
+        link: Link
+        txt: The party on %date%, at/in %location%
+    btn:
+        party_link: Go to this party
+        manage_link: Manage this party
     message:
-        html: 'Hi there, <br /><br />You have requested us to resend your activation mail with the event manage link(s)<br />'
+        html: 'Hi there, <br /><br />You have requested us to send an overview of all the parties you need to know about. These parties are all the parties you have created or where you are participating in, taking place in the future:<br />'
         txt: >
             Hi there,
 
-            You have requested us to resend your activation mail with the event manage link(s)
+            You have requested us to send an overview of all the parties you need to know about. These parties are all the parties you have created or where you are participating in, taking place in the future:
 
 # Emails/participant.{html,txt}.twig
 emails-participant:
@@ -604,8 +614,8 @@ flashes:
 
     # ForgotManagementURLController
     forgot_management_url:
-        success: 'We have successfully resend your activation mail'
-        error: 'An error occurred while resending the activation mail. Please try again.'
+        success: 'We have successfully sent you an overview!'
+        error: 'An error occurred while sending the email. Check your email address and please try again.'
 
     # ManagementController
     management:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
@@ -114,10 +114,11 @@ pool-deleted:
     body: <p>Gracias por usar el Secret Santa Organizer. ¡Esperamos verte otra vez el próximo año!</p>
     create_new_list: ¡Crear una nueva lista Secret Santa!
 
-# Pool/forgotLink.html.twig
-pool-forgot_link:
-    title: Reenviar el correo de activación
-    description: Introduzca la dirección de email del propietario y reenviamos el correo de activación. Sólo funciona para grupos de evento que tuvieron lugar esta semana o que tendrán lugar en el futuro.
+# Party/forgotLink.html.twig
+party-forgot_link:
+#    title:
+#    description:
+#    submit_btn: ?
 
 # Wishlist/showAll.html.twig
 wishlist-show_all:
@@ -361,14 +362,20 @@ emails-emptyWishlistReminder:
 
 # Emails/forgotLink.{html,txt}.twig
 emails-forgot_link:
-    title: Tu lista Secret Santa
-    subject: Reenviar el correo de activación
-    message:
-        html: 'Hola, <br><br>tú nos has pedido a reenviar tu correo de activación con el enlace para ajustar tu evento.<br>'
-        txt: >
-            Hola,
-
-            tú nos has pedido a reenviar tu correo de activación con el enlace para ajustar tu evento.
+#    subject:
+#    participating_in:
+#    created_these:
+#    table_labels:
+#        date:
+#        location:
+#        link:
+#        txt:
+#    btn:
+#        party_link:
+#        manage_link:
+#    message:
+#        html: ?
+#        txt: ?
 
 # Emails/participant.{html,txt}.twig
 emails-participant:
@@ -514,8 +521,8 @@ flashes:
 
     # ForgotManagementURLController
     forgot_management_url:
-        success: 'Hemos enviado exitosamente reenviado su correo de activación.'
-        error: 'Se produjo un error durante la transmisión del correo de activación. Por favor, inténtalo de nuevo.'
+#        success:
+#        error:
 
     # ManagementController
     management:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
@@ -103,10 +103,11 @@ pool-deleted:
     body: <p>Merci d'avoir utilisé Secret Santa Organize. Et nous espérons vous revoir l'année prochaine !</p>
     create_new_list: Créez une nouvelle liste Secret Santa !
 
-# Pool/forgotLink.html.twig
-pool-forgot_link:
-    title: Renvoyer l'e-mail d'activation
-    description: Renseignez l'adresse e-mail de l'administrateur de la liste et nous renverrons l'e-mail d'activation. Cela ne concerne que les listes qui se sont déroulés la semaine dernière ou qui auront lieu prochainement. (Ceci enverra uniquement le lien de la page d'administration).
+# Party/forgotLink.html.twig
+party-forgot_link:
+#    title:
+#    description:
+#    submit_btn: ?
 
 # Wishlist/showAll.html.twig
 wishlist-show_all:
@@ -386,13 +387,20 @@ emails-emptyWishlistReminder:
 
 # Emails/forgotLink.{html,txt}.twig
 emails-forgot_link:
-    title: Votre liste Secret Santa
-    subject: Renvoie de l'e-mail d'activation
-    message:
-        html: Bonjour, <br /><br />Vous nous avez demandé de renvoyer votre e-mail d'activation avec le(s) lien(s) pour la gestion de l'événement.<br />
-        txt: >
-            Bonjour,
-            Vous nous avez demandé de renvoyer votre e-mail d'activation avec le(s) lien(s) pour la gestion de l'événement.
+#    subject:
+#    participating_in:
+#    created_these:
+#    table_labels:
+#        date:
+#        location:
+#        link:
+#        txt:
+#    btn:
+#        party_link:
+#        manage_link:
+#    message:
+#        html: ?
+#        txt: ?
 
 # Emails/participant.{html,txt}.twig
 emails-participant:
@@ -526,8 +534,8 @@ flashes:
 
     # ForgotManagementURLController
     forgot_management_url:
-        success: Nous avons bien renvoyé votre e-mail d'activation
-        error: Une erreur est survenue lors du renvoi de l'e-mail d'activation. Veuillez réessayer.
+#        success:
+#        error:
 
     # ManagementController
     management:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -153,8 +153,9 @@ static-faq:
         <a name="manage"></a><h2>Hoe beheer ik mijn evenement / deelnemers?</h2>
         <p>De bevestigingsmail die naar de lijstbeheerder werd gestuurd bevat een link naar de beheerpagina van de lijst.</p>
 
-        <a href="lost"></a><h2>Ik ben mijn bevestigingsmail kwijt.</h2>
-        <p>Als je de bevestigingsmail kwijt bent (deze bevat de link naar de beheerpagina van de lijst) is de wereld nog niet ontploft. Geef op <a href="http://www.secretsantaorganizer.com/forgot-link">deze pagina</a> het mailadres van de lijstbeheerder in en we sturen je een mail met de beheer link.</p>
+        <a href="lost"></a><h2>Ik ben mijn bevestigingsmail / link naar het feestje kwijt.</h2>
+        <p>Als je de bevestigingsmail kwijt bent (deze bevat de link naar de beheerpagina van de lijst of naar het feestje waaraan je meedoet) is de wereld nog niet ontploft. Geef op <a href="http://www.secretsantaorganizer.com/forgot-link">deze pagina</a> jouw mailadres in en we sturen je een mail met een
+        overzicht van alle feestjes waaraan je meedoet en/of die je hebt aangemaakt.</p>
 
         <a name="changes"></a><h2>Kan ik deelnemers toevoegen of verwijderen?</h2>
         <p>Je kan deelnemers toevoegen of verwijderen na het aanmaken van je evenement. Op de beheerpagina kan je een knop vinden om deelnemers te verwijderen en is er een formulier waarmee een deelnemer toegevoegd kan worden.

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -115,10 +115,11 @@ pool-deleted:
     body: <p>Bedankt voor het gebruik van de Secret Santa Organizer. Tot volgend jaar!</p>
     create_new_list: Stel een nieuwe Secret Santa lijst op!
 
-# Pool/forgotLink.html.twig
-pool-forgot_link:
-    title: Activatie mail opnieuw verzenden
-    description: Vul hier het emailadres van de eigenaar van het evenement in en wij versturen de activatie mail opnieuw. Dit is alleen mogelijk voor feestjes die plaatsvonden in de voorbije week of nog moeten plaatsvinden. (Hiermee wordt alleen de beheerpagina link gestuurd)
+# Party/forgotLink.html.twig
+party-forgot_link:
+    title: Overzicht van feestjes aanvraagen
+    description: Vul hier jouw emailadres in en we sturen je een overzicht van alle feestjes die je hebt gemaakt of waar je aan meedoet. We lijsten wel enkel de feestjes in de toekomst op.
+    submit_btn: Stuur me een overzicht
 
 # Wishlist/showAll.html.twig
 wishlist-show_all:
@@ -443,14 +444,25 @@ emails-emptyWishlistReminder:
 
 # Emails/forgotLink.{html,txt}.twig
 emails-forgot_link:
-    title: Jouw Secret Santa lijst
-    subject: Activatie mail opnieuw verzenden
+    subject: Overzicht van je feestjes
+    participating_in: Je neemt deel aan:
+    created_these: Je creëerde volgende feesjtes:
+    table_labels:
+        date: Datum
+        location: Locatie
+        link: Link
+        txt: Het feestje op %date%, te %location
+    btn:
+        party_link: Feestje bekijken
+        manage_link: Feestje beheren
     message:
-        html: 'Hallo, <br /><br />U heeft ons gevraagd om de activatie mail met de link(s) naar de beheerpagina opnieuw te verzenden<br />'
-        txt: >
-            Hallo,
+        html: 'Hey, <br /><br />Je hebt ons gevraagd een overzicht te sturen van jouw feestjes. Deze feestjes zijn alle feestjes die jij beheert en/of de feestjes waar jij aan meedoet, die plaatsvinden in de toekomst.<br />'
 
-            U heeft ons gevraagd om de activatie mail met de link(s) naar de beheerpagina opnieuw te verzenden
+        txt: >
+            Hey,
+
+            Je hebt ons gevraagd een overzicht te sturen van jouw feestjes. Deze feestjes zijn alle feestjes die jij beheert en/of de feestjes waar jij aan meedoet, die plaatsvinden in de toekomst.
+
 
 # Emails/participant.{html,txt}.twig
 emails-participant:
@@ -610,8 +622,8 @@ flashes:
 
     # ForgotManagementURLController
     forgot_management_url:
-        success: 'De activatie mail is succesvol opnieuw verstuurd!'
-        error: 'Er is een fout opgetreden tijdens het versturen van de activatie mail. Probeer nogmaals.'
+        success: 'We hebben je een email gestuurd met een overzicht van je feestjes!'
+        error: 'Er is een fout opgetreden tijdens het versturen van de mail. Probeer nogmaals.'
 
     # ManagementController
     management:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.no.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.no.yml
@@ -117,10 +117,11 @@ pool-deleted:
     body: <p>Takk for at du bruker Secret Santa Organizer. Vi håper å se deg igjen til neste år!</p>
     create_new_list: Opprett en ny Secret Santa-liste!
 
-# Pool/forgotLink.html.twig
-pool-forgot_link:
-    title: Send bekreftelsesepost på nytt
-    description: Skriv inn administrators epostadresse og vi sender en ny e-post med bekreftelse og link. Det fungerer kun for arrangement som ble opprettet den siste uken, eller som skal holdes i nærmeste framtid. (Dette sender kun en link til admin-siden)
+# Party/forgotLink.html.twig
+party-forgot_link:
+#    title:
+#    description:
+#    submit_btn: ?
 
 # Wishlist/showAll.html.twig
 #wishlist-show_all:
@@ -432,8 +433,17 @@ emails-emptyWishlistReminder:
 
 # Emails/forgotLink.{html,txt}.twig
 emails-forgot_link:
-    title: Din Secret Santa-liste
-#    subject: ?
+#    subject:
+#    participating_in:
+#    created_these:
+#    table_labels:
+#        date:
+#        location:
+#        link:
+#        txt:
+#    btn:
+#        party_link:
+#        manage_link:
 #    message:
 #        html: ?
 #        txt: ?
@@ -582,8 +592,8 @@ flashes:
 
     # ForgotManagementURLController
     forgot_management_url:
-        success: 'Vi har sendt en smånisse med en ny bekreftelsesepost til deg'
-        error: 'En feil inntraff mens din bekreftelsesepost ble sendt. Vennligst prøv igjen.'
+#        success: 'Vi har sendt en smånisse med en ny bekreftelsesepost til deg'
+#        error: 'En feil inntraff mens din bekreftelsesepost ble sendt. Vennligst prøv igjen.'
 
     # ManagementController
     management:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.pl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.pl.yml
@@ -97,10 +97,11 @@ pool-deleted:
     body: <p>Dziękujemy za skorzystanie z Tajnego Mikołaja. Mamy nadzieję, że spotkamy się ponownie w przyszłym roku!</p>
     create_new_list: Stwórz nową listę Tajnego Mikołaja!
 
-# Pool/forgotLink.html.twig
-#pool-forgot_link:
+# Party/forgotLink.html.twig
+#party-forgot_link:
 #    title: ?
 #    description: ?
+#    submit_btn: ?
 
 # Wishlist/showAll.html.twig
 #wishlist-show_all:
@@ -305,8 +306,17 @@ emails-emptyWishlistReminder:
 
 # Emails/forgotLink.{html,txt}.twig
 emails-forgot_link:
-    title: Twoja lista Tajnego Mikołaja
-#    subject:?
+#    subject:
+#    participating_in:
+#    created_these:
+#    table_labels:
+#        date:
+#        location:
+#        link:
+#        txt:
+#    btn:
+#        party_link:
+#        manage_link:
 #    message:
 #        html: ?
 #        txt: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.pt.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.pt.yml
@@ -110,10 +110,11 @@ pool-deleted:
     body: <p>Obrigado por ter utilizado o Secret Santa Organizer. Até o próximo ano!</p>
     create_new_list: Montar uma nova lista do Secret Santa!
 
-# Pool/forgotLink.html.twig
-#pool-forgot_link:
+# Party/forgotLink.html.twig
+#party-forgot_link:
 #    title: ?
 #    description: ?
+#    submit_btn: ?
 
 # Wishlist/showAll.html.twig
 #wishlist-show_all:
@@ -401,8 +402,17 @@ emails-emptyWishlistReminder:
 
 # Emails/forgotLink.{html,txt}.twig
 emails-forgot_link:
-    title: Sua lista Secret Santa
-#    subject:?
+#    subject:
+#    participating_in:
+#    created_these:
+#    table_labels:
+#        date:
+#        location:
+#        link:
+#        txt:
+#    btn:
+#        party_link:
+#        manage_link:
 #    message:
 #        html: ?
 #        txt: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.ru.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.ru.yml
@@ -113,10 +113,11 @@ pool-deleted:
     body: <p>Благодарим вас за использование сервиса Тайного Санты. Надеемся увидеть вас в следующем году!</p>
     create_new_list: Создать новый список Тайного Санты!
 
-# Pool/forgotLink.html.twig
-#pool-forgot_link:
+# Party/forgotLink.html.twig
+#party-forgot_link:
 #    title: ?
 #    description: ?
+#    submit_btn: ?
 
 # Wishlist/showAll.html.twig
 #wishlist-show_all:
@@ -343,8 +344,17 @@ emails-emptyWishlistReminder:
 
 # Emails/forgotLink.{html,txt}.twig
 emails-forgot_link:
-    title: Ваш список Тайного Санты
-#    subject: ?
+#    subject:
+#    participating_in:
+#    created_these:
+#    table_labels:
+#        date:
+#        location:
+#        link:
+#        txt:
+#    btn:
+#        party_link:
+#        manage_link:
 #    message:
 #        html: ?
 #        txt: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hans.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hans.yml
@@ -108,10 +108,11 @@ pool-deleted:
     body: <p>谢谢使用秘密圣诞老人组织机构。与此同时，我们希望下一年再见！</p>
     create_new_list: 创建一个新的秘密圣诞老人名单！
 
-# Pool/forgotLink.html.twig
-#pool-forgot_link:
+# Party/forgotLink.html.twig
+#party-forgot_link:
 #    title: ?
 #    description: ?
+#    submit_btn: ?
 
 # Wishlist/showAll.html.twig
 #wishlist-show_all:
@@ -338,8 +339,17 @@ emails-emptyWishlistReminder:
 
 # Emails/forgotLink.{html,txt}.twig
 emails-forgot_link:
-    title: 你的秘密圣诞老人名单
-#    subject: ?
+#    subject:
+#    participating_in:
+#    created_these:
+#    table_labels:
+#        date:
+#        location:
+#        link:
+#        txt:
+#    btn:
+#        party_link:
+#        manage_link:
 #    message:
 #        html: ?
 #        txt: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hant.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hant.yml
@@ -108,10 +108,11 @@ pool-deleted:
     body: <p>多謝你使用秘密聖誕老人 組織者，希望出年再見到你！</p>
     create_new_list: 創造新的秘密聖誕老人名單!
 
-# Pool/forgotLink.html.twig
-#pool-forgot_link:
+# Party/forgotLink.html.twig
+#party-forgot_link:
 #    title: ?
 #    description: ?
+#    submit_btn: ?
 
 # Wishlist/showAll.html.twig
 #wishlist-show_all:
@@ -338,8 +339,17 @@ emails-emptyWishlistReminder:
 
 # Emails/forgotLink.{html,txt}.twig
 emails-forgot_link:
-    title: 你的秘密聖誕老人目錄
-#    subject: ?
+#    subject:
+#    participating_in:
+#    created_these:
+#    table_labels:
+#        date:
+#        location:
+#        link:
+#        txt:
+#    btn:
+#        party_link:
+#        manage_link:
 #    message:
 #        html: ?
 #        txt: ?

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/forgotLink.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/forgotLink.html.twig
@@ -1,35 +1,69 @@
 {% extends "IntractoSecretSantaBundle:Emails:baseEmail.html.twig" %}
 {% block main %}
-    <table width="640" border="0" cellpadding="0" cellspacing="0" align="center">
+    <table width="640" border="0" cellpadding="0" cellspacing="0" align="center" style="font-family: Arial, Helvetica, sans-serif;">
         <tr>
             <td width="37" align="left">
             </td>
             <td width="566">
-                <span style="font-family: Arial, Helvetica, sans-serif; font-size: 15px; color:#333333; line-height: 25px;">
+                <span style="font-size: 15px; color:#333333; line-height: 25px;">
                     {{ 'emails-forgot_link.message.html'|trans|raw }}
 
                 </span>
-                <br/> <br/>
                 <br/>
-                {% for link in partyLinks %}
-                    <table class="button">
+                {% if manageLinks|length > 0 %}
+                    <h3>{{ 'emails-forgot_link.created_these'|trans }}</h3>
+                    <table style="width: 540px; font-family: Arial, Helvetica, sans-serif;">
                         <tr>
-                            <td align="center" width="auto" bgcolor="#bd1019" style="padding-top: 14px; padding-right: 40px; padding-bottom: 14px; padding-left: 40px;
-                            background: #bd1019; -webkit-box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2); -moz-box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
-                            box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2); -moz-border-radius: 6px; -webkit-border-radius: 6px; border-radius: 6px; color: #fff; border: solid 1px #5b1b1c;
-                            font-size: 10px; font-weight: normal; text-decoration: none; display: block;" class="buttonTop">
+                            <th>{{ 'emails-forgot_link.table_labels.date'|trans }}</th>
+                            <th>{{ 'emails-forgot_link.table_labels.location'|trans }}</th>
+                            <th>{{ 'emails-forgot_link.table_labels.link'|trans }}</th>
+                        </tr>
 
-                                <a href="{{ link.url }}" style="color: #FFF; text-decoration: none; font-family: Helvetica, Arial,
-                                sans-serif; vertical-align: baseline;">{{ link.text }}</a>
-
+                    {% for link in manageLinks %}
+                        <tr style="text-align: center;">
+                            <td>{{ link.date }}</td>
+                            <td>{{ link.location }}</td>
+                            <td>
+                                <table border="0" cellpadding="0" cellspacing="0" style="background-color:#bd1019; border:1px solid #353535; border-radius:3px; margin-left: auto;margin-right: auto;  margin-top: 5px; margin-bottom: 5px;">
+                                    <tr>
+                                        <td align="center" valign="middle" style="color:#FFFFFF; font-family:Helvetica, Arial, sans-serif; font-size:14px; letter-spacing:-.5px; line-height:150%; padding-top:5px; padding-right:10px; padding-bottom:5px; padding-left:10px;">
+                                            <a href="{{ link.url }}" style="color:#FFFFFF; text-decoration:none;">{{ 'emails-forgot_link.btn.manage_link'|trans }}</a>
+                                        </td>
+                                    </tr>
+                                </table>
                             </td>
                         </tr>
-                        <tr>
-                            <td width="auto" style="display: block; font-size: 16px;" class="buttonBottom">&nbsp;</td>
-                        </tr>
+                    {% endfor %}
                     </table>
-                    <br/>
-                {% endfor %}
+                    <br/> <br/>
+                {% endif %}
+                {% if participantLinks|length > 0 %}
+                    <h3>{{ 'emails-forgot_link.participating_in'|trans }}</h3>
+                    <table style="width: 540px; font-family: Arial, Helvetica, sans-serif;">
+                        <tr>
+                            <th>{{ 'emails-forgot_link.table_labels.date'|trans }}</th>
+                            <th>{{ 'emails-forgot_link.table_labels.location'|trans }}</th>
+                            <th>{{ 'emails-forgot_link.table_labels.link'|trans }}</th>
+                        </tr>
+
+                        {% for link in participantLinks %}
+                            <tr style="text-align: center;">
+                                <td>{{ link.date }}</td>
+                                <td>{{ link.location }}</td>
+                                <td>
+                                    <table border="0" cellpadding="0" cellspacing="0" style="background-color:#bd1019; border:1px solid #353535; border-radius:3px; margin-left: auto;margin-right: auto;  margin-top: 5px; margin-bottom: 5px;">
+                                        <tr>
+                                            <td align="center" valign="middle" style="color:#FFFFFF; font-family:Helvetica, Arial, sans-serif; font-size:14px; letter-spacing:-.5px; line-height:150%; padding-top:5px; padding-right:10px; padding-bottom:5px; padding-left:10px;">
+                                                <a href="{{ link.url }}" style="color:#FFFFFF; text-decoration:none;">{{ 'emails-forgot_link.btn.party_link'|trans }}</a>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                    <br/> <br/>
+                {% endif %}
             </td>
             <td width="37" align="right">
             </td>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Emails/forgotLink.txt.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Emails/forgotLink.txt.twig
@@ -1,4 +1,15 @@
-{{ 'emails-forgot_link.message.txt'|trans|raw }}<br>
-{% for link in partyLinks %}
-    <a href="{{ link.url }}">link.text</a>
+{{ 'emails-forgot_link.message.txt'|trans|raw }}
+
+{% if participantLinks|length > 0 %}
+{{ 'emails-forgot_link.participating_in'|trans }}
+{% for link in participantLinks %}
+    {{ 'emails-forgot_link.table_labels.txt'|trans({'%location%': link.location, '%date%': link.date}) }}: {{ link.url }}
 {% endfor %}
+{% endif %}
+
+{% if manageLinks|length > 0 %}
+{{ 'emails-forgot_link.created_these'|trans }}
+{% for link in manageLinks %}
+    {{ 'emails-forgot_link.table_labels.txt'|trans({'%location%': link.location, '%date%': link.date}) }}: {{ link.url }}
+{% endfor %}
+{% endif %}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Party/forgotLink.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Party/forgotLink.html.twig
@@ -2,9 +2,9 @@
 
 {% block main %}
     <div class="box">
-        <h1>{{ 'pool-forgot_link.title'|trans }}</h1>
+        <h1>{{ 'party-forgot_link.title'|trans }}</h1>
 
-        <p>{{ 'pool-forgot_link.description'|trans }}</p>
+        <p>{{ 'party-forgot_link.description'|trans }}</p>
         {{ form_start(form)}}
             {{ form_row(form._token) }}
             <div class="form-group">


### PR DESCRIPTION
The forgot email functionality now also works for participants, and not only for admins. When a user requests an email, he/she will receive an overview of all the parties he/she participates in and the parties he/she created. Only the parties of the past week and future are given. As described in #250 