### PR TITLE
Hiding some messages if party isn't started yet

### DIFF
--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.de.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.de.yml
@@ -288,6 +288,7 @@ party_manage_valid:
 #    remove_participant:
 #        title: ?
 #        body: ?
+#        party_started: ?
 
 #    updated_party:
 #        title: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -373,10 +373,9 @@ party_manage_valid:
 
     remove_participant:
         title: Delete this participant from your list
-        body: >
+        body: <p>Are you ABSOLUTELY sure?</p>
+        party_started: >
             <p>
-                Are you ABSOLUTELY sure?<br>
-                <br>
                 Deleting this participant has permanent consequences. You can't restore the current matches and the participant will be gone immeadiatly.<br>
                 <br>
                 Somebody might have bought them a present already.<br>

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
@@ -293,10 +293,9 @@ party_manage_valid:
 
     remove_participant:
         title: Expulsar este participante de mi lista
-        body: >
+        body: <p>¿Estás COMPLETAMENTE seguro?</p>
+        party_started: >
             <p>
-                ¿Estás COMPLETAMENTE seguro?<br>
-                <br>
                 Expulsar este participante causa consecuencias permanentes. No es possible de recuperar las atribuciones actuales y el participante serà borrado inmediatamente.<br>
                 <br>
                 Tiene en cuente que alguien ya puede ha comprado un regalo por este participante.<br>

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
@@ -318,10 +318,9 @@ party_manage_valid:
             </p>
     remove_participant:
         title: Supprimez ce participant de ma liste
-        body: >
+        body: <p>Etes-vous ABSOLUMENT certain ?</p>
+        party_started: >
             <p>
-                Etes-vous ABSOLUMENT certain ?<br>
-                <br>
                 Supprimer ce participant causera de conséquences permanentes. Il sera impossible de rétablir les attributions actuelles et le participant sera supprimé imméadiatement.<br>
                 <br>
                 Tenez compte de la possibilité que quelqu'un peut avoir déjà acheté un cadeau pour ce participant.<br>

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -380,10 +380,9 @@ party_manage_valid:
 
     remove_participant:
         title: Verwijder deze deelnemer uit je lijst
-        body: >
+        body: <p>Weet je het ECHT zeker?</p>
+        party_started: >
             <p>
-                Weet je het ECHT zeker?<br>
-                <br>
                 Het verwijderen van deze deelnemer heeft permanente gevolgen. Het is niet mogelijk om de huidige matches te herstellen en de deelnemer zal onmiddelijk verwijderd worden.<br>
                 <br>
                 Hou er ook rekening mee dat er iemand misschien al een geschenk heeft gekocht voor deze deelnemer.<br>

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.no.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.no.yml
@@ -365,13 +365,13 @@ party_manage_valid:
 
     remove_participant:
         title: Slett denne deltageren fra listen
+        party_started: <p>Er du HELT sikker?</p>
         body: >
             <p>
-                Er du HELT sikker?<br>
-                <br>
                 Å slette denne deltageren blir på permanent basis. DU kan ikke angre deg og personen denne deltageren har fått tildelt blir fjernet som kombinasjon.<br>
                 <br>
                 Noen kan ha kjøpt gaven allerede.<br>
+            </p>
 
     updated_party:
         title: Oppdater detaljer for festen

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.pl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.pl.yml
@@ -250,6 +250,7 @@ party_manage_valid:
 #    remove_participant:
 #        title: ?
 #        body: ?
+#        party_started: ?
 
 #    updated_party:
 #        title: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.pt.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.pt.yml
@@ -346,6 +346,7 @@ party_manage_valid:
 #    remove_participant:
 #        title: ?
 #        body: ?
+#        party_started: ?
 
 #    updated_party:
 #        title: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.ru.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.ru.yml
@@ -288,6 +288,7 @@ party_manage_valid:
 #    remove_participant:
 #        title: ?
 #        body: ?
+#        party_started: ?
 
 #    updated_party:
 #        title: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hans.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hans.yml
@@ -283,6 +283,7 @@ party_manage_valid:
 #    remove_participant:
 #        title: ?
 #        body: ?
+#        party_started: ?
 
 #    updated_party:
 #        title: ?

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hant.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hant.yml
@@ -283,6 +283,7 @@ party_manage_valid:
 #    remove_participant:
 #        title: ?
 #        body: ?
+#        party_started: ?
 
 #    updated_party:
 #        title: ?

--- a/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
@@ -102,6 +102,9 @@
             <h3>{{ 'party_manage_valid.remove_participant.title'|trans|raw }}</h3>
 
             {{ 'party_manage_valid.remove_participant.body'|trans|raw }}
+            {% if party.created %}
+                {{ 'party_manage_valid.remove_participant.party_started'|trans|raw }}
+            {% endif %}
             <br>
             <form id="delete-participant-form" method="post">
                 <input type="hidden" name="csrf_token" value="{{ delete_participant_csrf_token }}">
@@ -114,9 +117,12 @@
                 </button>
             </form>
         </div>
-        <div class="alert alert-info">
-            <strong>{{ 'party_manage_valid.manage.tip'|trans }}</strong> {{ 'party_manage_valid.manage.come_back'|trans }}
-        </div>
+
+        {% if party.created %}
+            <div class="alert alert-info">
+                <strong>{{ 'party_manage_valid.manage.tip'|trans }}</strong> {{ 'party_manage_valid.manage.come_back'|trans }}
+            </div>
+        {% endif %}
 
         {% if not party.created and party.participants | length >3  %}
             <div class="panel panel-default" id="messagePanel">


### PR DESCRIPTION
Some messages on the manage page are now hidden when the party isn't started yet:
- The info box containing the tip to check if someone opened their mail
- The warning when deleting a participant is less severe

Closes #259