### PR TITLE
#260 : Personal message can now be updated after creation

### DIFF
--- a/src/Intracto/SecretSantaBundle/Controller/Party/ManagementController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Party/ManagementController.php
@@ -47,6 +47,13 @@ class ManagementController extends Controller
             ]
         );
 
+        // Functionality has been added on the 19th of April 2017
+        // Since that day, only the custom message (The message admins can provide when creating the party) is saved in the database, and not the whole email.
+        // Therefore only parties created after the 19th of April 2017 are able to use this functionality, to prevent users from editing the whole email.
+        if ($party->getCreated() || $party->getCreationDate() < new \DateTime('2017-04-20')) {
+            $updatePartyDetailsForm->remove('message');
+        }
+        
         if ($party->getEventdate() < new \DateTime('-2 years')) {
             return $this->render('IntractoSecretSantaBundle:Party/manage:expired.html.twig', [
                 'party' => $party,

--- a/src/Intracto/SecretSantaBundle/Controller/Party/PartyController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Party/PartyController.php
@@ -101,21 +101,7 @@ class PartyController extends Controller
                     $participant->setParty($party);
                 }
 
-                $dateFormatter = \IntlDateFormatter::create(
-                    $request->getLocale(),
-                    \IntlDateFormatter::MEDIUM,
-                    \IntlDateFormatter::NONE
-                );
-
-                $message = $this->get('translator')->trans('party_controller.created.message', [
-                    '%amount%' => $party->getAmount(),
-                    '%eventdate%' => $dateFormatter->format($party->getEventdate()->getTimestamp()),
-                    '%location%' => $party->getLocation(),
-                    '%message%' => $party->getMessage(),
-                ]);
-
                 $party->setCreationDate(new \DateTime());
-                $party->setMessage($message);
                 $party->setLocale($request->getLocale());
 
                 $this->get('doctrine.orm.entity_manager')->persist($party);

--- a/src/Intracto/SecretSantaBundle/Entity/Party.php
+++ b/src/Intracto/SecretSantaBundle/Entity/Party.php
@@ -35,7 +35,7 @@ class Party
     /**
      * @var string
      *
-     * @ORM\Column(name="message", type="text")
+     * @ORM\Column(name="message", type="text", nullable=true)
      */
     private $message;
 

--- a/src/Intracto/SecretSantaBundle/Form/Type/UpdatePartyDetailsType.php
+++ b/src/Intracto/SecretSantaBundle/Form/Type/UpdatePartyDetailsType.php
@@ -5,6 +5,7 @@ namespace Intracto\SecretSantaBundle\Form\Type;
 use Intracto\SecretSantaBundle\Entity\Party;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -19,6 +20,7 @@ class UpdatePartyDetailsType extends AbstractType
             ])
             ->add('amount', TextType::class, ['label' => 'form-party.label.amount_to_spend'])
             ->add('location', TextType::class, ['label' => 'form-party.label.location'])
+            ->add('message', TextareaType::class, ['label' => 'form-party.label.message'])
         ;
     }
 

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.de.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.de.yml
@@ -15,6 +15,7 @@ form-party:
         date_party: Datum Ihrer Secret Santa-Party
         location: Platz von Ihrer Secret Santa-Party
         amount_to_spend: Auszugebender Betrag
+#        message:
 
 # PartyController
 party_controller:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -15,6 +15,7 @@ form-party:
         date_party: Date of your Secret Santa party
         location: Location of your Secret Santa party
         amount_to_spend: Amount to spend
+        message: Additional message in email
 
 # PartyController
 party_controller:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
@@ -15,6 +15,7 @@ form-party:
         date_party: Fecha de tu fiesta Secret Santa
         location: Sitio de tu fiesta Secret Santa
         amount_to_spend: Cantidad a gastar
+#        message:
 
 # PartyController
 party_controller:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
@@ -15,6 +15,7 @@ form-party:
         date_party: Date de votre Secret Santa party
         location: Lieu
         amount_to_spend: Montant à dépenser
+#        message:
 
 # PartyController
 party_controller:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -15,6 +15,7 @@ form-party:
         date_party: Datum van jouw Secret Santa feest
         location: Locatie van jouw Secret Santa feest
         amount_to_spend: Te spenderen bedrag
+        message: Extra bericht in email
 
 # PartyController
 party_controller:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.no.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.no.yml
@@ -15,6 +15,7 @@ form-party:
         date_party: Dato
         location: Sted
         amount_to_spend: Beløp å bruke på gaven
+#        message:
 
 # PartyController
 party_controller:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.pl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.pl.yml
@@ -15,6 +15,7 @@ form-party:
         date_party: Data Twojego Przyjęcia Tajnego Mikołaja
 #        location: ?
         amount_to_spend: Suma do wydania
+#        message:
 
 # PartyController
 party_controller:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.pt.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.pt.yml
@@ -15,6 +15,7 @@ form-party:
         date_party: Data da sua festa de Amigo Secreto
 #        location: ?
         amount_to_spend: Valor máximo a gastar
+#        message:
 
 # PartyController
 party_controller:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.ru.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.ru.yml
@@ -15,6 +15,7 @@ form-party:
         date_party: Дата проведения твоей вечеринки Тайного Санты
 #        location: ?
         amount_to_spend: Сумма
+#        message:
 
 # PartyController
 party_controller:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hans.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hans.yml
@@ -15,6 +15,7 @@ form-party:
         date_party: 你的秘密圣诞老人派对日期
 #        location: ?
         amount_to_spend: 消费金额
+#        message:
 
 # PartyController
 party_controller:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hant.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hant.yml
@@ -15,6 +15,7 @@ form-party:
         date_party: 秘密聖誕老人派對日期
 #        location: ?
         amount_to_spend: 費用
+#        message:
 
 # PartyController
 party_controller:

--- a/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
@@ -250,6 +250,15 @@
                         <strong>{{ error.message }}</strong><br>
                     {% endfor %}
                 </div>
+                {% if updatePartyDetailsForm.message is defined %}
+                    <div class="form-group {% if form_errors(updatePartyDetailsForm.message) %}error{% endif %}">
+                        <strong>{{ form_label(updatePartyDetailsForm.message) }}</strong>
+                        {{ form_widget(updatePartyDetailsForm.message, {'attr': {'class': 'form-control'}}) }}
+                        {% for error in updatePartyDetailsForm.message.vars.errors %}
+                            <strong>{{ error.message }}</strong><br>
+                        {% endfor %}
+                    </div>
+                {% endif %}
                 <button type="submit" class="btn btn-warning" id="btn_update_confirmation">Update party details</button>
                 <button type="reset" class="btn btn-warning" id="btn_update_cancel">{{ 'party_manage_valid.btn.cancel'|trans }}</button>
             {{ form_end(updatePartyDetailsForm) }}


### PR DESCRIPTION
The personal message which is sent with the initial email, to the participants can now be changed after the creation of the party. This can't be changed when party has started. Since only the custom message is saved in the database now, and not the whole email, only parties created after 19th of April 2017 can use this function.
Closes #260