### PR TITLE
Bughunt

### DIFF
--- a/src/Intracto/SecretSantaBundle/Controller/WishlistController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/WishlistController.php
@@ -54,7 +54,7 @@ class WishlistController extends Controller
 
         $wishlistForm->handleRequest($request);
 
-        if (! $wishlistForm->isValid()) {
+        if (!$wishlistForm->isValid()) {
             $return = ['responseCode' => 400, 'message' => 'Form invalid!'];
 
             return new JsonResponse($return);

--- a/src/Intracto/SecretSantaBundle/Controller/WishlistController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/WishlistController.php
@@ -54,54 +54,58 @@ class WishlistController extends Controller
 
         $wishlistForm->handleRequest($request);
 
-        if ($wishlistForm->isValid()) {
-            // save participants passed and check rank
-            $inOrder = true;
-            $lastRank = 0;
-            $newWishlistItems = $participant->getWishlistItems();
+        if (! $wishlistForm->isValid()) {
+            $return = ['responseCode' => 400, 'message' => 'Form invalid!'];
 
-            foreach ($newWishlistItems as $item) {
-                $item->setParticipant($participant);
-                $this->get('doctrine.orm.entity_manager')->persist($item);
-                // keep track of rank
-                if ($item->getRank() < $lastRank) {
-                    $inOrder = false;
-                }
-                $lastRank = $item->getRank();
+            return new JsonResponse($return);
+        }
+
+        // save participants passed and check rank
+        $inOrder = true;
+        $lastRank = 0;
+        $newWishlistItems = $participant->getWishlistItems();
+
+        foreach ($newWishlistItems as $item) {
+            $item->setParticipant($participant);
+            $this->get('doctrine.orm.entity_manager')->persist($item);
+            // keep track of rank
+            if ($item->getRank() < $lastRank) {
+                $inOrder = false;
             }
+            $lastRank = $item->getRank();
+        }
 
-            // remove participants not passed
-            foreach ($currentWishlistItems as $item) {
-                if (!$newWishlistItems->contains($item)) {
-                    $this->get('doctrine.orm.entity_manager')->remove($item);
-                }
+        // remove participants not passed
+        foreach ($currentWishlistItems as $item) {
+            if (!$newWishlistItems->contains($item)) {
+                $this->get('doctrine.orm.entity_manager')->remove($item);
             }
+        }
 
-            // For now assume that a save of participant means the list has changed
-            $time_now = new \DateTime();
-            $participant->setWishlistUpdated(true);
-            $participant->setWishlistUpdatedTime($time_now);
+        // For now assume that a save of participant means the list has changed
+        $time_now = new \DateTime();
+        $participant->setWishlistUpdated(true);
+        $participant->setWishlistUpdatedTime($time_now);
 
-            $this->get('doctrine.orm.entity_manager')->persist($participant);
-            $this->get('doctrine.orm.entity_manager')->flush();
+        $this->get('doctrine.orm.entity_manager')->persist($participant);
+        $this->get('doctrine.orm.entity_manager')->flush();
 
-            if (!$request->isXmlHttpRequest()) {
-                $this->get('session')->getFlashBag()->add(
-                    'success',
-                    $this->get('translator')->trans('flashes.participant.wishlist_updated')
-                );
+        if (!$request->isXmlHttpRequest()) {
+            $this->get('session')->getFlashBag()->add(
+                'success',
+                $this->get('translator')->trans('flashes.participant.wishlist_updated')
+            );
 
-                if (!$inOrder) {
-                    // redirect to force refresh of form and entity
-                    return $this->redirect($this->generateUrl('participant_view', ['url' => $url]));
-                }
+            if (!$inOrder) {
+                // redirect to force refresh of form and entity
+                return $this->redirect($this->generateUrl('participant_view', ['url' => $url]));
             }
+        }
 
-            if ($request->isXmlHttpRequest()) {
-                $return = ['responseCode' => 200, 'message' => 'Added!'];
+        if ($request->isXmlHttpRequest()) {
+            $return = ['responseCode' => 200, 'message' => 'Added!'];
 
-                return new JsonResponse($return);
-            }
+            return new JsonResponse($return);
         }
     }
 }

--- a/src/Intracto/SecretSantaBundle/Resources/views/Participant/show/valid.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Participant/show/valid.html.twig
@@ -126,7 +126,6 @@
         </div>
 
         {{ form_start(wishlistForm, {'attr': {'id': 'add_item_to_wishlist_form'}}) }}
-        {{ form_row(wishlistForm._token) }}
 
         <table class="participants table table-striped">
             <thead>


### PR DESCRIPTION
Bugsnag detected an error: "The controller must return a response (null given). Did you forget to add a return statement somewhere in your controller?". This occurs when the wishlist form is invalid. I think the only way that it can be invalid is when the CSRF token expires. It's session bound and when people keep the page open on their mobile or some browser tab, that can happen. The wishlist page works with AJAX and doesn't handle/refresh the CSRF token like it should.

I got lots of error reports from people that the wishlist was not saving the items. I guess this explains it.

Fixes:
- The controller now returns a message when the form is invalid.
- The CSRF token is removed.

Someone can attempt to re-implement the CSRF token in a way it is doing it's job and is refreshing etc. I'm fine with the CSRF token being removed.

Note that this is not the exact bug that is mentioned in #234 but it's very close. I've seen that bug the last time on 3 apr. And right after that we started seeing this "The controller must return a response" bug.

To be honest. I think we've squashed this little annoying bug guys.

I suggest we merge and deploy these fixes and keep bugsnag for another week to be sure.