### PR TITLE
Fix #281 : Adding items to wishlist fixed

### DIFF
--- a/src/Intracto/SecretSantaBundle/Form/Type/WishlistType.php
+++ b/src/Intracto/SecretSantaBundle/Form/Type/WishlistType.php
@@ -25,6 +25,7 @@ class WishlistType extends AbstractType
         $resolver->setDefaults(
             [
                 'data_class' => Participant::class,
+                'csrf_protection' => false,
             ]
         );
     }


### PR DESCRIPTION
CSRF Was removed  in #270 due to problems with saving the wishlist if the site was open for a longer time (on tablet etc..), but CSRF check was not disabled. Thence wishlists were not saved anymore.
Closes #281 