### PR TITLE
#280 Link back to manage page from wishlist/matches pages

### DIFF
--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.de.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.de.yml
@@ -110,6 +110,7 @@ party-deleted:
 # Wishlist/showAll.html.twig
 #wishlist-show_all:
 #    title: ?
+#    back:
 
 # Static/faq.html.twig
 static-faq:
@@ -134,6 +135,7 @@ participant-expose_all:
     title: Treffer des Secret Santa-Mail-Verteilers
     giving: Dieses Mitglied gibt....
     receiving: ... diesem Mitglied ein Geschenk
+#    back:
 
 # Participant/show/base.html.twig
 participant_show_base:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -121,6 +121,7 @@ party-get_reuse_url:
 # Wishlist/showAll.html.twig
 wishlist-show_all:
     title: All Secret Santa Wishlists
+    back: Back to manage page
 
 # Static/faq.html.twig
 static-faq:
@@ -218,6 +219,7 @@ participant-expose_all:
     title: Secret Santa Mailing List Matches
     giving: This member is giving ...
     receiving: ... a gift to this member
+    back: Back to manage page
 
 # Participant/show/base.html.twig
 participant_show_base:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.es.yml
@@ -108,6 +108,7 @@ party-forgot_link:
 # Wishlist/showAll.html.twig
 wishlist-show_all:
     title: Secret Santa Listas de deseos
+#    back:
 
 # Static/faq.html.twig
 static-faq:
@@ -132,6 +133,7 @@ participant-expose_all:
     title: Secret Santa Mailing List Matches
     giving: This member is giving ...
     receiving: ... a gift to this member
+#    back:
 
 # Participant/show/base.html.twig
 participant_show_base:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.fr.yml
@@ -97,6 +97,7 @@ party-forgot_link:
 # Wishlist/showAll.html.twig
 wishlist-show_all:
     title: Listes de souhaits Secret Santa
+#    back:
 
 # Static/faq.html.twig
 static-faq:
@@ -160,6 +161,7 @@ participant-expose_all:
     title: Liste des attributions Secret Santa
     giving: Ce membre donne ...
     receiving: ... un cadeau à ce membre
+#    back:
 
 # Participant/show/base.html.twig
 participant_show_base:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -118,6 +118,7 @@ party-get_reuse_url:
 # Wishlist/showAll.html.twig
 wishlist-show_all:
     title: Secret Santa Mailinglijst verlanglijsten
+    back: Terug naar de beheerpagina
 
 # Static/faq.html.twig
 static-faq:
@@ -223,6 +224,7 @@ participant-expose_all:
     title: Secret Santa Mailinglijst Koppelingen
     giving: Dit lid geeft ...
     receiving: ... een cadeau aan dit lid
+    back: Terug naar beheerpagina
 
 # Participant/show/base.html.twig
 participant_show_base:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.no.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.no.yml
@@ -111,6 +111,7 @@ party-forgot_link:
 # Wishlist/showAll.html.twig
 #wishlist-show_all:
 #    title: ?
+#    back:
 
 # Static/faq.html.twig
 static-faq:
@@ -204,6 +205,7 @@ helper-prototype_wishlist:
 #    title: ?
 #    giving: ?
 #    receiving: ?
+#    back:
 
 # Participant/show/base.html.twig
 participant_show_base:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.pl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.pl.yml
@@ -100,6 +100,7 @@ party-deleted:
 # Wishlist/showAll.html.twig
 #wishlist-show_all:
 #    title: ?
+#    back:
 
 # Static/faq.html.twig
 static-faq:
@@ -124,6 +125,7 @@ participant-expose_all:
     title: Dopasowania na liście Tajnych Mikołajów
     giving: Ten uczestnik podaruje...
     receiving: ... prezent dla tego uczestnika
+#    back:
 
 # Participant/show/base.html.twig
 participant_show_base:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.pt.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.pt.yml
@@ -104,6 +104,7 @@ party-deleted:
 # Wishlist/showAll.html.twig
 #wishlist-show_all:
 #    title: ?
+#    back:
 
 # Static/faq.html.twig
 static-faq:
@@ -186,9 +187,10 @@ helper-prototype_wishlist:
 
 # Participant/exposeAll.html.twig
 participant-expose_all:
-      title: Combinações do Amigo Secreto
-      giving:  Este participante é o Papai Noel de ...
-#      receiving: ?
+    title: Combinações do Amigo Secreto
+    giving:  Este participante é o Papai Noel de ...
+#    receiving: ?
+#    back:
 
 # Participant/show/base.html.twig
 participant_show_base:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.ru.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.ru.yml
@@ -107,6 +107,7 @@ party-deleted:
 # Wishlist/showAll.html.twig
 #wishlist-show_all:
 #    title: ?
+#    back:
 
 # Static/faq.html.twig
 static-faq:
@@ -131,6 +132,7 @@ participant-expose_all:
     title: Пары из списка Тайного Санты
     giving: Это участник готовит подарок...
     receiving: ... для этого участника
+#    back:
 
 # Participant/show/base.html.twig
 participant_show_base:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hans.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hans.yml
@@ -102,6 +102,7 @@ party-deleted:
 # Wishlist/showAll.html.twig
 #wishlist-show_all:
 #    title: ?
+#    back:
 
 # Static/faq.html.twig
 static-faq:
@@ -126,6 +127,7 @@ helper-prototype_wishlist:
 #    title: ?
 #    giving: ?
 #    receiving: ?
+#    back:
 
 # Participant/show/base.html.twig
 participant_show_base:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hant.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.zh-Hant.yml
@@ -102,6 +102,7 @@ party-deleted:
 # Wishlist/showAll.html.twig
 #wishlist-show_all:
 #    title: ?
+#    back:
 
 # Static/faq.html.twig
 static-faq:
@@ -126,6 +127,7 @@ helper-prototype_wishlist:
 #    title: ?
 #    giving: ?
 #    receiving: ?
+#    back:
 
 # Participant/show/base.html.twig
 participant_show_base:

--- a/src/Intracto/SecretSantaBundle/Resources/views/Participant/exposeAll.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Participant/exposeAll.html.twig
@@ -2,6 +2,7 @@
 
 {% block main %}
     <div class="box">
+        <a href="{{ path('party_manage', {'listUrl': party.listurl}) }}" ><i class="fa fa-chevron-left" aria-hidden="true"></i> {{ 'participant-expose_all.back'|trans }}</a>
         <h1>{{ 'participant-expose_all.title'|trans }}</h1>
         <table cellspacing="0" cellpadding="3" class="table table-striped table-hover mysanta">
             <thead>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Wishlist/showAll.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Wishlist/showAll.html.twig
@@ -2,6 +2,7 @@
 
 {% block main %}
     <div class="box">
+        <a href="{{ path('party_manage', {'listUrl': party.listurl}) }}" ><i class="fa fa-chevron-left" aria-hidden="true"></i> {{ 'wishlist-show_all.back'|trans }}</a>
         <h1>{{ 'wishlist-show_all.title'|trans }}</h1>
             {% for participant in party.participants %}
                 <h3>{{ participant.name }}</h3>


### PR DESCRIPTION
Placed a link back to the manage on the pages where you can view all matches and view all the wishlists from the participants.
Closes #280 