### PR TITLE
#294: Switch ORM mapping to XML and cleanup

### DIFF
--- a/src/Intracto/SecretSantaBundle/Entity/BlacklistEmail.php
+++ b/src/Intracto/SecretSantaBundle/Entity/BlacklistEmail.php
@@ -2,49 +2,21 @@
 
 namespace Intracto\SecretSantaBundle\Entity;
 
-use Doctrine\ORM\Mapping as ORM;
-
-/**
- * @ORM\Table(name="blacklist_email")
- * @ORM\Entity
- */
 class BlacklistEmail
 {
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    /** @var int */
     private $id;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="email", type="text", nullable=false)
-     */
+    /** @var string */
     private $email;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="ipv4", type="string", nullable=true)
-     */
+    /** @var string */
     private $ipv4;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="ipv6", type="string", nullable=true)
-     */
+    /** @var string */
     private $ipv6;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="date", type="datetime", nullable=true)
-     */
+    /** @var \DateTime */
     private $date;
 
     /**

--- a/src/Intracto/SecretSantaBundle/Entity/Participant.php
+++ b/src/Intracto/SecretSantaBundle/Entity/Participant.php
@@ -2,52 +2,30 @@
 
 namespace Intracto\SecretSantaBundle\Entity;
 
-use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
-use Intracto\SecretSantaBundle\Validator\ParticipantHasValidExcludes;
 use Doctrine\Common\Collections\ArrayCollection;
+use Intracto\SecretSantaBundle\Validator\ParticipantHasValidExcludes;
 use Intracto\SecretSantaBundle\Validator\ParticipantIsNotBlacklisted;
 
 /**
- * @ORM\Table(name="participant", indexes={@ORM\Index(name="participant_url", columns={"url"})})
- * @ORM\Entity(repositoryClass="Intracto\SecretSantaBundle\Entity\ParticipantRepository")
- * @ORM\HasLifecycleCallbacks()
- *
  * @ParticipantHasValidExcludes(groups={"exclude_participants"})
  */
 class Participant
 {
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    /** @var int */
     private $id;
 
-    /**
-     * @var Party
-     *
-     * @ORM\ManyToOne(targetEntity="Party", inversedBy="participants")
-     * @ORM\JoinColumn(name="party_id", referencedColumnName="id", onDelete="CASCADE")
-     */
+    /** @var Party */
     private $party;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="name", type="string", length=255)
-     *
      * @Assert\NotBlank()
      */
     private $name;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="email", type="string", length=255)
-     *
      * @Assert\NotBlank()
      * @Assert\Email(
      *     strict=true,
@@ -58,155 +36,63 @@ class Participant
      */
     private $email;
 
-    /**
-     * @var Participant
-     *
-     * @ORM\OneToOne(targetEntity="Participant")
-     * @ORM\JoinColumn(name="assigned_participant_id", referencedColumnName="id", nullable=true, onDelete="SET NULL")
-     */
+    /** @var Participant */
     private $participant;
 
-    /**
-     * @var ArrayCollection
-     *
-     * @ORM\ManyToMany(targetEntity="Participant")
-     * @ORM\JoinTable(name="exclude",
-     *      joinColumns={@ORM\JoinColumn(name="participant_id", referencedColumnName="id")},
-     *      inverseJoinColumns={@ORM\JoinColumn(name="excluded_participant_id", referencedColumnName="id")}
-     *      )
-     **/
+    /** @var ArrayCollection */
     private $excludedParticipants;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="view_date", type="datetime", nullable=true)
-     */
+    /** @var \DateTime */
     private $viewdate;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="open_email_date", type="datetime", nullable=true)
-     */
+    /** @var \DateTime */
     private $openEmailDate;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="view_reminder_sent", type="datetime", nullable=true)
-     */
+    /** @var \DateTime */
     private $viewReminderSentTime;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="url", type="string", length=255, nullable=true)
-     */
+    /** @var string */
     private $url;
 
-    /**
-     * @var WishlistItem[]
-     *
-     * @ORM\OneToMany(targetEntity="WishlistItem", mappedBy="participant", cascade={"persist", "remove"})
-     * @ORM\OrderBy({"rank" = "asc"})
-     */
+    /** @var WishlistItem[] */
     private $wishlistItems;
 
-    /**
-     * @var WishlistItem[]
-     */
-    private $removedWishlistItems;
-
-    /**
-     * @var bool
-     *
-     * @ORM\Column(name="wishlist_updated", type="boolean", nullable=true)
-     */
+    /** @var bool */
     private $wishlistUpdated = false;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="update_wishlist_reminder_sent", type="datetime", nullable=true)
-     */
+    /** @var \DateTime */
     private $updateWishlistReminderSentTime;
 
-    /**
-     * @var bool
-     *
-     * @ORM\Column(name="party_admin", type="boolean", options={"default"=false})
-     */
+    /** @var bool */
     private $partyAdmin = false;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="ipv4", type="string", nullable=true)
-     */
+    /** @var string */
     private $ipv4;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="ipv6", type="string", nullable=true)
-     */
+    /** @var string */
     private $ipv6;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="party_status_sent", type="datetime", nullable=true)
-     */
+    /** @var \DateTime */
     private $partyStatusSentTime;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="empty_wishlist_reminder_sent", type="datetime", nullable=true)
-     */
+    /** @var \DateTime */
     private $emptyWishlistReminderSentTime;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="wishlist_updated_time", type="datetime", nullable=true)
-     */
+    /** @var \DateTime */
     private $wishlistUpdatedTime;
 
-    /**
-     * @var bool
-     *
-     * @ORM\Column(name="subscribed_for_updates", type="boolean", options={"default"=true})
-     */
+    /** @var bool */
     private $subscribedForUpdates = true;
 
-    /**
-     * @var bool
-     *
-     * @ORM\Column(name="email_did_bounce", type="boolean", options={"default"=false})
-     */
+    /** @var bool */
     private $emailDidBounce = false;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="invitation_sent_date", type="datetime", nullable=true)
-     */
+    /** @var \DateTime */
     private $invitationSentDate;
 
     public function __construct()
     {
         $this->excludedParticipants = new ArrayCollection();
-        $this->postLoad();
-    }
-
-    /**
-     * @ORM\PostLoad
-     */
-    public function postLoad()
-    {
-        $this->removedWishlistItems = new ArrayCollection();
     }
 
     /**
@@ -413,38 +299,6 @@ class Participant
     public function setWishlistItems($wishlistItems)
     {
         $this->wishlistItems = $wishlistItems;
-    }
-
-    public function addWishlistItem(WishlistItem $item)
-    {
-        $this->removedWishlistItems->removeElement($item);
-        $item->setParticipant($this);
-        $this->wishlistItems->add($item);
-        $this->wishlistUpdated = true;
-    }
-
-    public function removeWishlistItem(WishlistItem $item)
-    {
-        $this->removedWishlistItems->add($item);
-        $item->setParticipant(null);
-        $this->wishlistItems->removeElement($item);
-        $this->wishlistUpdated = true;
-    }
-
-    /**
-     * @return WishlistItem[]
-     */
-    public function getRemovedWishlistItems()
-    {
-        return $this->removedWishlistItems;
-    }
-
-    /**
-     * @param WishlistItem $removedWishlistItems
-     */
-    public function setRemovedWishlistItems($removedWishlistItems)
-    {
-        $this->removedWishlistItems = $removedWishlistItems;
     }
 
     /**

--- a/src/Intracto/SecretSantaBundle/Entity/Party.php
+++ b/src/Intracto/SecretSantaBundle/Entity/Party.php
@@ -2,101 +2,57 @@
 
 namespace Intracto\SecretSantaBundle\Entity;
 
-use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 use Intracto\SecretSantaBundle\Validator\PartyHasValidExcludes;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * @ORM\Table(name="party", indexes={@ORM\Index(name="list_url", columns={"list_url"}),@ORM\Index(name="dates", columns={"created", "event_date", "sent_date"})})
- * @ORM\Entity(repositoryClass="Intracto\SecretSantaBundle\Entity\PartyRepository")
- * @ORM\HasLifecycleCallbacks
- *
  * @PartyHasValidExcludes(groups={"exclude_participants"})
  */
 class Party
 {
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    /** @var int */
     private $id;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="list_url", type="string", length=255)
-     */
+    /** @var string */
     private $listurl;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="message", type="text", nullable=true)
-     */
+    /** @var string */
     private $message;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="creation_date", type="datetime", length=255)
-     */
+    /** @var \DateTime */
     private $creationdate;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="sent_date", type="datetime", length=255, nullable=true)
-     */
+    /** @var \DateTime */
     private $sentdate;
 
     /**
      * @var \DateTime
-     *
      * @Assert\NotBlank()
-     * @ORM\Column(name="event_date", type="datetime", length=255, nullable=true)
      */
     private $eventdate;
 
     /**
      * @var string
-     *
      * @Assert\NotBlank()
-     * @ORM\Column(name="amount", type="string", length=255, nullable=true)
      */
     private $amount;
 
     /**
      * @var ArrayCollection
-     *
-     * @ORM\OneToMany(targetEntity="Participant", mappedBy="party", cascade={"persist", "remove"})
-     *
      * @Assert\Valid()
      */
     private $participants;
 
-    /**
-     * @var bool
-     *
-     * @ORM\Column(name="created", type="boolean")
-     */
+    /** @var bool */
     private $created = false;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="locale", type="string", length=7)
-     */
+    /** @var string */
     private $locale = 'en';
 
     /**
      * @var string
-     *
      * @Assert\NotBlank()
-     * @ORM\Column(name="location", type="string", length=255, nullable=true)
      */
     private $location;
 

--- a/src/Intracto/SecretSantaBundle/Entity/WishlistItem.php
+++ b/src/Intracto/SecretSantaBundle/Entity/WishlistItem.php
@@ -2,54 +2,24 @@
 
 namespace Intracto\SecretSantaBundle\Entity;
 
-use Doctrine\ORM\Mapping as ORM;
-
-/**
- * @ORM\Table(name="wishlist_item")
- * @ORM\Entity
- */
 class WishlistItem
 {
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    /** @var int */
     private $id;
 
-    /**
-     * @var Participant
-     *
-     * @ORM\ManyToOne(targetEntity="Participant", inversedBy="wishlistItems")
-     */
+    /** @var Participant */
     private $participant;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="description", type="text", nullable=true)
-     */
+    /** @var string */
     private $description;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="image", type="string", length=255, nullable=true)
-     */
+    /** @var string */
     private $image;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="rank", type="integer", nullable=true)
-     */
+    /** @var int */
     private $rank;
 
-    /**
-     * @return int
-     */
+    /** @return int */
     public function getId()
     {
         return $this->id;

--- a/src/Intracto/SecretSantaBundle/Resources/config/doctrine/BlacklistEmail.orm.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/doctrine/BlacklistEmail.orm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                   https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+
+    <entity name="Intracto\SecretSantaBundle\Entity\BlacklistEmail" table="blacklist_email">
+
+        <id name="id" type="integer">
+            <generator strategy="AUTO" />
+        </id>
+
+        <field name="email" column="email" type="text" nullable="false" />
+        <field name="ipv4" column="ipv4" type="string" nullable="true" />
+        <field name="ipv6" column="ipv6" type="string" nullable="true" />
+        <field name="date" column="date" type="datetime" nullable="true" /> <!-- @todo: rename. Date is a no-go -->
+
+    </entity>
+
+</doctrine-mapping>

--- a/src/Intracto/SecretSantaBundle/Resources/config/doctrine/BlacklistEmail.orm.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/doctrine/BlacklistEmail.orm.xml
@@ -8,13 +8,13 @@
     <entity name="Intracto\SecretSantaBundle\Entity\BlacklistEmail" table="blacklist_email">
 
         <id name="id" type="integer">
-            <generator strategy="AUTO" />
+            <generator strategy="AUTO"/>
         </id>
 
-        <field name="email" column="email" type="text" nullable="false" />
-        <field name="ipv4" column="ipv4" type="string" nullable="true" />
-        <field name="ipv6" column="ipv6" type="string" nullable="true" />
-        <field name="date" column="date" type="datetime" nullable="true" /> <!-- @todo: rename. Date is a no-go -->
+        <field name="email" column="email" type="text" nullable="false"/>
+        <field name="ipv4" column="ipv4" type="string" nullable="true"/>
+        <field name="ipv6" column="ipv6" type="string" nullable="true"/>
+        <field name="date" column="date" type="datetime" nullable="true"/>
 
     </entity>
 

--- a/src/Intracto/SecretSantaBundle/Resources/config/doctrine/BlacklistEmail.orm.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/doctrine/BlacklistEmail.orm.xml
@@ -14,7 +14,7 @@
         <field name="email" column="email" type="text" nullable="false"/>
         <field name="ipv4" column="ipv4" type="string" nullable="true"/>
         <field name="ipv6" column="ipv6" type="string" nullable="true"/>
-        <field name="date" column="date" type="datetime" nullable="true"/>
+        <field name="date" column="date_blacklisted" type="datetime" nullable="true"/>
 
     </entity>
 

--- a/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Participant.orm.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Participant.orm.xml
@@ -5,7 +5,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                    https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
 
-    <entity name="Intracto\SecretSantaBundle\Entity\Participant" table="participant">
+    <entity name="Intracto\SecretSantaBundle\Entity\Participant" table="participant" repository-class="Intracto\SecretSantaBundle\Entity\ParticipantRepository">
 
         <indexes>
             <index name="participant_url" columns="url"/>

--- a/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Participant.orm.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Participant.orm.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" ?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                   https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+
+    <entity name="Intracto\SecretSantaBundle\Entity\Participant" table="participant">
+
+        <indexes>
+            <index name="participant_url" columns="url"/>
+        </indexes>
+
+        <id name="id" type="integer">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <many-to-one field="party" target-entity="Party" inversed-by="participants">
+            <join-column name="party_id" referenced-column-name="id" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="name" column="name" type="string" length="255"/>
+        <field name="email" column="email" type="string" length="255"/>
+
+        <one-to-one field="participant" target-entity="Participant">
+            <join-column name="assigned_participant_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
+        </one-to-one>
+
+        <many-to-many field="excludedParticipants" target-entity="Participant">
+            <join-table name="exclude">
+                <join-columns>
+                    <join-column name="participant_id" referenced-column-name="id"/>
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="excluded_participant_id" referenced-column-name="id"/>
+                </inverse-join-columns>
+            </join-table>
+        </many-to-many>
+
+        <field name="viewdate" column="view_date" type="datetime" nullable="true"/>
+        <field name="openEmailDate" column="open_email_date" type="datetime" nullable="true"/>
+        <field name="viewReminderSentTime" column="view_reminder_sent" type="datetime" nullable="true"/>
+        <field name="url" column="url" type="string" length="255" nullable="true"/>
+
+        <one-to-many field="wishlistItems" target-entity="WishlistItem" mapped-by="participant">
+            <order-by>
+                <order-by-field name="rank" direction="ASC" />
+            </order-by>
+            <cascade>
+                <cascade-persist/>
+                <cascade-remove/>
+            </cascade>
+        </one-to-many>
+
+        <field name="wishlistUpdated" column="wishlist_updated" type="boolean" nullable="true"/>
+        <field name="updateWishlistReminderSentTime" column="update_wishlist_reminder_sent" type="datetime" nullable="true"/>
+        <field name="partyAdmin" column="party_admin" type="boolean">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="ipv4" column="ipv4" type="string" nullable="true"/>
+        <field name="ipv6" column="ipv6" type="string" nullable="true"/>
+        <field name="partyStatusSentTime" column="party_status_sent" type="datetime" nullable="true"/>
+        <field name="emptyWishlistReminderSentTime" column="empty_wishlist_reminder_sent" type="datetime" nullable="true"/>
+        <field name="wishlistUpdatedTime" column="wishlist_updated_time" type="datetime" nullable="true"/>
+        <field name="subscribedForUpdates" column="subscribed_for_updates" type="boolean">
+            <options>
+                <option name="default">1</option>
+            </options>
+        </field>
+        <field name="emailDidBounce" column="email_did_bounce" type="boolean">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="invitationSentDate" column="invitation_sent_date" type="datetime" nullable="true"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Participant.orm.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Participant.orm.xml
@@ -44,7 +44,7 @@
 
         <one-to-many field="wishlistItems" target-entity="WishlistItem" mapped-by="participant">
             <order-by>
-                <order-by-field name="rank" direction="ASC" />
+                <order-by-field name="rank" direction="ASC"/>
             </order-by>
             <cascade>
                 <cascade-persist/>

--- a/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Party.orm.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Party.orm.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                   https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+
+    <entity name="Intracto\SecretSantaBundle\Entity\Party" table="party" repository-class="Intracto\SecretSantaBundle\Entity\PartyRepository">
+
+        <indexes>
+            <index name="list_url" columns="list_url"/>
+            <index name="dates" columns="created,event_date,sent_date"/>
+        </indexes>
+
+        <id name="id" type="integer">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="listurl" column="list_url" type="string" length="255"/>
+        <field name="message" column="message" type="text" nullable="true"/>
+        <field name="creationdate" column="creation_date" type="datetime"/>
+        <field name="sentdate" column="sent_date" type="datetime" nullable="true"/>
+        <field name="eventdate" column="event_date" type="datetime" nullable="true"/>
+        <field name="amount" column="amount" type="string" length="255" nullable="true"/>
+
+        <one-to-many field="participants" target-entity="Participant" mapped-by="party">
+            <cascade>
+                <cascade-remove/>
+                <cascade-persist/>
+            </cascade>
+        </one-to-many>
+
+        <field name="created" column="created" type="boolean"/>
+        <field name="locale" column="locale" type="string" length="7"/>
+        <field name="location" column="location" type="string" length="255" nullable="true"/>
+    </entity>
+
+</doctrine-mapping>

--- a/src/Intracto/SecretSantaBundle/Resources/config/doctrine/WishlistItem.orm.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/doctrine/WishlistItem.orm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                   https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+
+    <entity name="Intracto\SecretSantaBundle\Entity\WishlistItem" table="wishlist_item">
+
+        <id name="id" type="integer">
+            <generator strategy="AUTO" />
+        </id>
+
+        <many-to-one field="participant" target-entity="Participant" inversed-by="wishlistItems">
+            <join-column name="participant_id" referenced-column-name="id" />
+        </many-to-one>
+
+        <field name="description" column="description" type="text" nullable="true" />
+        <field name="image" column="image" type="string" nullable="true" />
+        <field name="rank" column="rank" type="integer" nullable="true" />
+
+    </entity>
+
+</doctrine-mapping>

--- a/src/Intracto/SecretSantaBundle/Resources/config/doctrine/WishlistItem.orm.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/doctrine/WishlistItem.orm.xml
@@ -8,16 +8,16 @@
     <entity name="Intracto\SecretSantaBundle\Entity\WishlistItem" table="wishlist_item">
 
         <id name="id" type="integer">
-            <generator strategy="AUTO" />
+            <generator strategy="AUTO"/>
         </id>
 
         <many-to-one field="participant" target-entity="Participant" inversed-by="wishlistItems">
-            <join-column name="participant_id" referenced-column-name="id" />
+            <join-column name="participant_id" referenced-column-name="id"/>
         </many-to-one>
 
-        <field name="description" column="description" type="text" nullable="true" />
-        <field name="image" column="image" type="string" nullable="true" />
-        <field name="rank" column="rank" type="integer" nullable="true" />
+        <field name="description" column="description" type="text" nullable="true"/>
+        <field name="image" column="image" type="string" nullable="true"/>
+        <field name="rank" column="rank" type="integer" nullable="true"/>
 
     </entity>
 


### PR DESCRIPTION
ORM mapping does not belong in the Entities. So, moving this to XML. This is also a next step towards making it easy to do some "domain modelling and ddd".