### PR TITLE
Refactor unsubscribe controller

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -20,6 +20,7 @@ default:
                    - Intracto\Behat\Features\Context\Bootstrap\StartedPartyManagementContext
                    - Intracto\Behat\Features\Context\Bootstrap\ResendPartyInfoContext
                    - Intracto\Behat\Features\Context\Bootstrap\ReusePartyLinkContext
+                   - Intracto\Behat\Features\Context\Bootstrap\UnsubscribeContext
 
     extensions:
         Behat\MinkExtension:

--- a/src/Intracto/Behat/Features/Context/Bootstrap/UnsubscribeContext.php
+++ b/src/Intracto/Behat/Features/Context/Bootstrap/UnsubscribeContext.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Intracto\Behat\Features\Context\Bootstrap;
+
+use Behat\Behat\Tester\Exception\PendingException;
+use Behat\MinkExtension\Context\RawMinkContext;
+use Behat\Symfony2Extension\Context\KernelDictionary;
+use Intracto\Behat\Features\Context\FeatureContext;
+
+class UnsubscribeContext extends RawMinkContext
+{
+    use KernelDictionary;
+
+    /**
+     * @Given /^I am on the unsubscribe page$/
+     */
+    public function iAmOnTheUnsubscribePage()
+    {
+        $path = $this->getContainer()->get('router')->generate('unsubscribe_confirm', ['url' => FeatureContext::PARTICIPANT_URL_TOKEN]);
+        $this->visitPath($path);
+    }
+
+    /**
+     * @When /^I want to unsubscribe from all parties$/
+     */
+    public function iWantToAddMyselfToTheBlacklist()
+    {
+        $this->getSession()->getPage()->find('css', '#unsubscribe_allParties')->click();
+
+        $this->getSession()->getPage()->find('css', '#unsubscribe_button')->click();
+    }
+
+    /**
+     * @When /^I submit the form with selecting an option$/
+     */
+    public function iSubmitTheFormWithSelectingAnOption()
+    {
+        $this->getSession()->getPage()->find('css', '#unsubscribe_button')->click();
+    }
+}

--- a/src/Intracto/Behat/Features/unsubscribe.feature
+++ b/src/Intracto/Behat/Features/unsubscribe.feature
@@ -1,0 +1,12 @@
+@javascript @fixtures
+Feature: A user is able to unsubscribe from all emails
+
+  Scenario: I want to unsubscribe from
+    Given I am on the unsubscribe page
+    When I want to unsubscribe from all parties
+    Then I should see a success message
+
+  Scenario: Submitting without options should show an error
+    Given I am on the unsubscribe page
+    When I submit the form with selecting an option
+    Then I should see a error message

--- a/src/Intracto/SecretSantaBundle/Controller/UnsubscribeController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/UnsubscribeController.php
@@ -9,69 +9,27 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class UnsubscribeController extends Controller
 {
     /**
      * @Route("/unsubscribe/{url}", name="unsubscribe_confirm")
      * @Template("IntractoSecretSantaBundle:Participant:unsubscribe.html.twig")
-     * @Method("GET")
+     * @Method({"GET", "POST"})
      */
-    public function confirmAction($url)
+    public function confirmAction(Request $request, Participant $participant)
     {
-        /** @var Participant $participant */
-        $participant = $this->get('intracto_secret_santa.repository.participant')->findOneByUrl($url);
-        if ($participant === null) {
-            throw new NotFoundHttpException();
+        $form = $this->createForm(UnsubscribeType::class);
+        $handler = $this->get('intracto_secret_santa.form_handler.unsubcribe');
+
+        if ($handler->handle($form, $request, $participant)) {
+            return $this->redirect($this->generateUrl('homepage'));
         }
 
-        $unsubscribeForm = $this->createForm(
-            UnsubscribeType::class,
-            null,
-            [
-                'action' => $this->generateUrl(
-                    'unsubscribe_action',
-                    ['url' => $participant->getUrl()]
-                ),
-            ]
-        );
-
         return [
-            'unsubscribeForm' => $unsubscribeForm->createView(),
+            'unsubscribeForm' => $form->createView(),
             'participant' => $participant,
             'party' => $participant->getParty(),
         ];
-    }
-
-    /**
-     * @Route("/unsubscribe/{url}", name="unsubscribe_action")
-     * @Method("POST")
-     */
-    public function unsubscribeAction(Request $request, $url)
-    {
-        $unsubscribeForm = $this->createForm(UnsubscribeType::class);
-        $unsubscribeForm->handleRequest($request);
-
-        if ($unsubscribeForm->isValid()) {
-            $participant = $this->get('intracto_secret_santa.repository.participant')->findOneByUrl($url);
-            $allParties = $unsubscribeForm->getData()['allParties'];
-            $blacklist = $unsubscribeForm->getData()['blacklist'];
-
-            if ($blacklist) {
-                $ip = $request->getClientIp();
-                $this->get('intracto_secret_santa.service.unsubscribe')->blacklist($participant, $ip);
-            } else {
-                $this->get('intracto_secret_santa.service.unsubscribe')->unsubscribe($participant, $allParties);
-            }
-
-            $this->addFlash('success', $this->get('translator')->trans('participant_unsubscribe.feedback.success'));
-        } else {
-            $this->addFlash('danger', $this->get('translator')->trans('participant_unsubscribe.feedback.error'));
-
-            return $this->redirect($this->generateUrl('unsubscribe_confirm', ['url' => $url]));
-        }
-
-        return $this->redirect($this->generateUrl('homepage'));
     }
 }

--- a/src/Intracto/SecretSantaBundle/Form/Handler/UnsubscribeFormHandler.php
+++ b/src/Intracto/SecretSantaBundle/Form/Handler/UnsubscribeFormHandler.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace Intracto\SecretSantaBundle\Form\Handler;
+
+use Intracto\SecretSantaBundle\Entity\Participant;
+use Intracto\SecretSantaBundle\Service\UnsubscribeService;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class UnsubscribeFormHandler
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var Session
+     */
+    private $session;
+
+    /**
+     * @var UnsubscribeService
+     */
+    private $unsubscribeService;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param Session             $session
+     * @param UnsubscribeService  $unsubscribeService
+     */
+    public function __construct(TranslatorInterface $translator, Session $session, UnsubscribeService $unsubscribeService)
+    {
+        $this->translator = $translator;
+        $this->session = $session;
+        $this->unsubscribeService = $unsubscribeService;
+    }
+
+    /**
+     * @param FormInterface $form
+     * @param Request       $request
+     * @param Participant   $participant
+     *
+     * @return bool
+     */
+    public function handle(FormInterface $form, Request $request, Participant $participant) : bool
+    {
+
+        if (!$request->isMethod('POST')) {
+            return false;
+        }
+
+        if (!$form->handleRequest($request)->isValid()) {
+            $this->session->getFlashBag()->add('danger', $this->translator->trans('participant_unsubscribe.feedback.error'));
+
+            return false;
+        }
+
+        $unsubscribeData = $form->getData();
+
+        if (false === $unsubscribeData['blacklist'] && false === $unsubscribeData['allParties']) {
+            $this->session->getFlashBag()->add('danger', $this->translator->trans('participant_unsubscribe.feedback.error_atleast_one_option'));
+
+            return false;
+        }
+
+        if ($unsubscribeData['blacklist']) {
+            $this->unsubscribeService->blacklist($participant, $request->getClientIp());
+        } else {
+            $this->unsubscribeService->unsubscribe($participant, $unsubscribeData['allParties']);
+        }
+
+        $this->session->getFlashBag()->add('success', $this->translator->trans('participant_unsubscribe.feedback.success'));
+
+        return true;
+    }
+}

--- a/src/Intracto/SecretSantaBundle/Resources/config/services.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/services.xml
@@ -95,6 +95,11 @@
             <argument type="service" id="doctrine.orm.default_entity_manager" />
             <argument type="service" id="intracto_secret_santa.mailer" />
         </service>
+        <service id="intracto_secret_santa.form_handler.unsubcribe" class="Intracto\SecretSantaBundle\Form\Handler\UnsubscribeFormHandler">
+            <argument type="service" id="translator" />
+            <argument type="service" id="session" />
+            <argument type="service" id="intracto_secret_santa.service.unsubscribe" />
+        </service>
 
         <!-- Validators -->
         <service id="intracto_secret_santa.validator.participant_has_valid_excludes" class="Intracto\SecretSantaBundle\Validator\ParticipantHasValidExcludesValidator">

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.en.yml
@@ -300,6 +300,7 @@ participant_unsubscribe:
     feedback:
         success: You have successfully unsubscribed!
         error: There was an error when unsubscribing, please try again!
+        error_atleast_one_option: Choose at least one unsubscribe option.
 
 # Party/manage/base.html.twig
 party_manage_base:

--- a/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
+++ b/src/Intracto/SecretSantaBundle/Resources/translations/messages.nl.yml
@@ -305,6 +305,7 @@ participant_unsubscribe:
     feedback:
        success: Je bent succesvol uitgeschreven!
        error: Er is een probleem opgetreden tijdens het uitschrijven, probeer opnieuw!
+       error_atleast_one_option: Kies minstens 1 uitschrijf mogelijkheid.
 
 # Party/manage/base.html.twig
 party_manage_base:

--- a/src/Intracto/SecretSantaBundle/Resources/views/Participant/unsubscribe.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Participant/unsubscribe.html.twig
@@ -22,7 +22,7 @@
             {{ form_widget(unsubscribeForm.blacklist) }}
             {{ form_label(unsubscribeForm.blacklist) }}
         </div>
-        <button type="submit" class="btn btn-default">{{ 'participant_unsubscribe.unsubscribe_confirm_btn' |trans }}</button>
+        <button type="submit" id="unsubscribe_button" class="btn btn-default">{{ 'participant_unsubscribe.unsubscribe_confirm_btn' |trans }}</button>
         {{ form_end(unsubscribeForm) }}
     </div>
 {% endblock main %}


### PR DESCRIPTION
Moved the app logic away from the controller

- Make use of the doctrine paramconverter
- Use a form handler class to remove all application logic for handling forms

With this refactor I've also fixed a bug when an user did not select any of the two checkboxes on the page (+ behat tests for this page and the fixed bug)