### PR TITLE
General controller cleanup

### DIFF
--- a/src/Intracto/SecretSantaBundle/Controller/ForgotURLController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/ForgotURLController.php
@@ -24,7 +24,7 @@ class ForgotURLController extends Controller
         $handler = $this->get('intracto_secret_santa.form_handler.forgot_url');
 
         if ($handler->handle($form, $request)) {
-            return $this->redirect($this->generateUrl('homepage'));
+            return $this->redirectToRoute('homepage');
         }
 
         return [

--- a/src/Intracto/SecretSantaBundle/Controller/HomepageController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/HomepageController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Intracto\SecretSantaBundle\Controller;
 
@@ -18,13 +19,9 @@ class HomepageController extends Controller
      */
     public function indexAction()
     {
-        $partyForm = $this->createForm(
-            PartyType::class,
-            new Party(),
-            [
-                'action' => $this->generateUrl('create_party'),
-            ]
-        );
+        $partyForm = $this->createForm(PartyType::class, new Party(), [
+            'action' => $this->generateUrl('create_party'),
+        ]);
 
         return [
             'form' => $partyForm->createView(),

--- a/src/Intracto/SecretSantaBundle/Controller/Participant/DumpParticipantsController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Participant/DumpParticipantsController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Intracto\SecretSantaBundle\Controller\Participant;
 

--- a/src/Intracto/SecretSantaBundle/Controller/Participant/ExposeParticipantsController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Participant/ExposeParticipantsController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Intracto\SecretSantaBundle\Controller\Participant;
 

--- a/src/Intracto/SecretSantaBundle/Controller/Participant/ResendParticipantController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Participant/ResendParticipantController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Intracto\SecretSantaBundle\Controller\Participant;
 
@@ -6,7 +7,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Intracto\SecretSantaBundle\Entity\Participant;
 
 class ResendParticipantController extends Controller
@@ -19,23 +19,17 @@ class ResendParticipantController extends Controller
     public function resendAction($listurl, Participant $participant)
     {
         if ($participant->getParty()->getListurl() !== $listurl) {
-            throw new NotFoundHttpException();
+            $this->createNotFoundException();
         }
 
         if ($this->get('intracto_secret_santa.service.unsubscribe')->isBlacklisted($participant)) {
-            $this->get('session')->getFlashBag()->add(
-                'danger',
-                $this->get('translator')->trans('flashes.resend_participant.blacklisted')
-            );
+            $this->addFlash('danger', $this->get('translator')->trans('flashes.resend_participant.blacklisted'));
         } else {
             $this->get('intracto_secret_santa.mailer')->sendSecretSantaMailForParticipant($participant);
 
-            $this->get('session')->getFlashBag()->add(
-                'success',
-                $this->get('translator')->trans('flashes.resend_participant.resent', ['%email%' => $participant->getName()])
-            );
+            $this->addFlash('success', $this->get('translator')->trans('flashes.resend_participant.resent', ['%email%' => $participant->getName()]));
         }
 
-        return $this->redirect($this->generateUrl('party_manage', ['listurl' => $listurl]));
+        return $this->redirectToRoute('party_manage', ['listurl' => $listurl]);
     }
 }

--- a/src/Intracto/SecretSantaBundle/Controller/Participant/ShowController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Participant/ShowController.php
@@ -8,7 +8,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Intracto\SecretSantaBundle\Form\Type\WishlistType;
 use Intracto\SecretSantaBundle\Form\Type\AnonymousMessageFormType;
 use Intracto\SecretSantaBundle\Entity\Participant;

--- a/src/Intracto/SecretSantaBundle/Controller/ParticipantCommunicationController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/ParticipantCommunicationController.php
@@ -6,7 +6,6 @@ namespace Intracto\SecretSantaBundle\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Intracto\SecretSantaBundle\Form\Type\AnonymousMessageFormType;
 
@@ -22,6 +21,6 @@ class ParticipantCommunicationController extends Controller
 
         $this->get('intract_secret_santa.form_handler.send_message')->handle($form, $request);
 
-        return $this->redirect($this->generateUrl('participant_view', ['url' => $form->getData()['participant']]));
+        return $this->redirectToRoute('participant_view', ['url' => $form->getData()['participant']]);
     }
 }

--- a/src/Intracto/SecretSantaBundle/Controller/Party/PartyController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Party/PartyController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Intracto\SecretSantaBundle\Controller\Party;
 
@@ -54,23 +55,17 @@ class PartyController extends Controller
      */
     public function deleteAction(Request $request, Party $party)
     {
-        $correctCsrfToken = $this->isCsrfTokenValid(
-            'delete_party',
-            $request->get('csrf_token')
-        );
+        $correctCsrfToken = $this->isCsrfTokenValid('delete_party', $request->get('csrf_token'));
         $correctConfirmation = (strtolower($request->get('confirmation')) === strtolower($this->get('translator')->trans('party_manage_valid.delete.phrase_to_type')));
 
         if ($correctConfirmation === false || $correctCsrfToken === false) {
-            $this->get('session')->getFlashBag()->add(
-                'error',
-                $this->get('translator')->trans('flashes.party.not_deleted')
-            );
+            $this->addFlash('error', $this->get('translator')->trans('flashes.party.not_deleted'));
 
-            return $this->redirect($this->generateUrl('party_manage', ['listurl' => $party->getListurl()]));
+            return $this->redirectToRoute('party_manage', ['listurl' => $party->getListurl()]);
         }
 
-        $this->get('doctrine.orm.entity_manager')->remove($party);
-        $this->get('doctrine.orm.entity_manager')->flush();
+        $this->getDoctrine()->getManager()->remove($party);
+        $this->getDoctrine()->getManager()->flush();
     }
 
     /**
@@ -89,9 +84,7 @@ class PartyController extends Controller
         $handler = $this->get('intracto_secret_santa.form_handler.party');
 
         if ($handler->handle($form, $request)) {
-            return $this->redirect(
-                $this->generateUrl('party_created', ['listurl' => $party->getListurl()])
-            );
+            return $this->redirectToRoute('party_created', ['listurl' => $party->getListurl()]);
         }
 
         return [

--- a/src/Intracto/SecretSantaBundle/Controller/Party/SendPartyUpdateController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Party/SendPartyUpdateController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Intracto\SecretSantaBundle\Controller\Party;
 
@@ -6,7 +7,6 @@ use Intracto\SecretSantaBundle\Entity\Party;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class SendPartyUpdateController extends Controller
 {
@@ -20,11 +20,8 @@ class SendPartyUpdateController extends Controller
 
         $this->get('intracto_secret_santa.mailer')->sendPartyUpdateMailForParty($party, $results);
 
-        $this->get('session')->getFlashBag()->add(
-            'success',
-            $this->get('translator')->trans('flashes.send_party_update.success')
-        );
+        $this->addFlash('success', $this->get('translator')->trans('flashes.send_party_update.success'));
 
-        return $this->redirect($this->generateUrl('party_manage', ['listurl' => $party->getListurl()]));
+        return $this->redirectToRoute('party_manage', ['listurl' => $party->getListurl()]);
     }
 }

--- a/src/Intracto/SecretSantaBundle/Controller/ReuseController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/ReuseController.php
@@ -24,7 +24,7 @@ class ReuseController extends Controller
         $handler = $this->get('intracto_secret_santa.form_handler.reuse');
 
         if ($handler->handle($form, $request)) {
-            return $this->redirect($this->generateUrl('homepage'));
+            return $this->redirectToRoute('homepage');
         }
 
         return [

--- a/src/Intracto/SecretSantaBundle/Controller/TrackingController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/TrackingController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Intracto\SecretSantaBundle\Controller;
 

--- a/src/Intracto/SecretSantaBundle/Controller/UnsubscribeController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/UnsubscribeController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Intracto\SecretSantaBundle\Controller;
 
@@ -23,7 +24,7 @@ class UnsubscribeController extends Controller
         $handler = $this->get('intracto_secret_santa.form_handler.unsubcribe');
 
         if ($handler->handle($form, $request, $participant)) {
-            return $this->redirect($this->generateUrl('homepage'));
+            return $this->redirectToRoute('homepage');
         }
 
         return [


### PR DESCRIPTION
This PR does some general controller clean up. This prepares the controllers so we extended from `AbstractController` to avoid calling the container directly

- Use strict_types
- Make sure we use the controller helper functions instead of accessing the container directly
- Some general code style