### PR TITLE
Use ubuntu trusty and upgrade selenium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 sudo: false
+dist: trusty
 
 language: php
+
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
 
 env:
     global:

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -10,15 +10,15 @@ chromium-browser --version
 
 # Download and configure ChromeDriver
 if [ ! -f $BUILD_CACHE_DIR/chromedriver ]; then
-    # Using ChromeDriver 2.12 which supports Chrome 36-40, we're using Chromium 37
-    curl http://chromedriver.storage.googleapis.com/2.12/chromedriver_linux64.zip > chromedriver.zip
+    # Using ChromeDriver 2.30 which supports Chrome 58-60, we're using Chromium 59
+    curl http://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip > chromedriver.zip
     unzip chromedriver.zip
     mv chromedriver $BUILD_CACHE_DIR
 fi
 
 # Run Selenium with ChromeDriver
 echo "Start selenium"
-bin/selenium-server-standalone -Dwebdriver.chrome.driver=$BUILD_CACHE_DIR/chromedriver > $TRAVIS_BUILD_DIR/selenium.log 2>&1 &
+PATH=\"$BUILD_CACHE_DIR:\$PATH\" bin/selenium-server-standalone > $TRAVIS_BUILD_DIR/selenium.log 2>&1 &
 
 # Run phpunit tests (Temporary re-enable xdebug to generate coverage report)
 phpenv config-add ~/xdebug.ini

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "behat/mink-extension": "^2.2",
         "behat/mink-selenium2-driver": "^1.3",
         "behat/symfony2-extension": "^2.1",
-        "se/selenium-server-standalone": "^2.53",
+        "se/selenium-server-standalone": "^3.4",
         "friends-of-behat/performance-extension": "^1.0",
         "lakion/mink-debug-extension": "^1.2",
         "sensiolabs/behat-page-object-extension": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ecc4b78aa1c861691b970138f9e8d413",
+    "content-hash": "aea027e53454affe036063d0a8dad0e5",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -5346,16 +5346,16 @@
         },
         {
             "name": "se/selenium-server-standalone",
-            "version": "v2.53.1",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sveneisenschmidt/selenium-server-standalone.git",
-                "reference": "ef4eea9c99efb9c0e3084e9cae625662ccd43361"
+                "reference": "86da4447676b2dfd00688ac43db102cf831682af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sveneisenschmidt/selenium-server-standalone/zipball/ef4eea9c99efb9c0e3084e9cae625662ccd43361",
-                "reference": "ef4eea9c99efb9c0e3084e9cae625662ccd43361",
+                "url": "https://api.github.com/repos/sveneisenschmidt/selenium-server-standalone/zipball/86da4447676b2dfd00688ac43db102cf831682af",
+                "reference": "86da4447676b2dfd00688ac43db102cf831682af",
                 "shasum": ""
             },
             "require-dev": {
@@ -5381,7 +5381,7 @@
                 "selenium",
                 "testing"
             ],
-            "time": "2016-07-01T14:16:52+00:00"
+            "time": "2017-04-27T11:26:21+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/docs/behat.md
+++ b/docs/behat.md
@@ -8,7 +8,7 @@ This test suite uses google chrome to run the behat features. To run the tests l
 Start selenium with the google chrome webdriver
 
 ```bash
-bin/selenium-server-standalone -Dwebdriver.chrome.driver=/path/to/chromedriver
+PATH="/path/to/chromedriver:$PATH" bin/selenium-server-standalone
 ```
 
 Start the behat suite


### PR DESCRIPTION
- Travis will switch to trusty soon but this will allow us to use the new containers already
- Chrome 59 is included in the new containers, so selenium can be upgraded (and hopefully the fullpage screenshots will be fixed)