### PR TITLE
Forward compatibility with sf 3.4 autowiring

### DIFF
--- a/src/Intracto/SecretSantaBundle/Twig/Extension/FormExtension.php
+++ b/src/Intracto/SecretSantaBundle/Twig/Extension/FormExtension.php
@@ -2,8 +2,8 @@
 
 namespace Intracto\SecretSantaBundle\Twig\Extension;
 
+use Symfony\Component\Form\FormRendererInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Bridge\Twig\Form\TwigRendererInterface;
 
 class FormExtension extends \Twig_Extension
 {
@@ -16,9 +16,9 @@ class FormExtension extends \Twig_Extension
     public $renderer;
 
     /**
-     * @param TwigRendererInterface $renderer
+     * @param FormRendererInterface $renderer
      */
-    public function __construct(TwigRendererInterface $renderer)
+    public function __construct(FormRendererInterface $renderer)
     {
         $this->renderer = $renderer;
     }


### PR DESCRIPTION
`TwigRendererInterface` is deprecated and in 3.4 the `twig.renderer` service will switch to the `FormRenderer` class