### PR TITLE
Switch date to numbers only

### DIFF
--- a/src/Intracto/SecretSantaBundle/Form/Extension/DateTypeExtension.php
+++ b/src/Intracto/SecretSantaBundle/Form/Extension/DateTypeExtension.php
@@ -17,7 +17,7 @@ class DateTypeExtension extends AbstractTypeExtension
     {
         $resolver->setDefaults(array(
             'widget' => 'single_text',
-            'format' => 'dd-MM-yyyy',
+            'format' => 'dd-mm-yyyy',
             'append' => '<i class="icon-calendar"></i>',
             'start_date' => 'today',
             'end_date' => '31-12-2100',


### PR DESCRIPTION
If date is displayed in the language of the user, this can fail at our side. See:
![image1](https://user-images.githubusercontent.com/391674/32092997-fddeb6f0-bafa-11e7-88a5-acdaa7b413e4.png)
