### PR TITLE
Fix: Language switcher

### DIFF
--- a/src/Intracto/SecretSantaBundle/Controller/Party/PartyController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Party/PartyController.php
@@ -18,10 +18,13 @@ class PartyController extends AbstractController
     /**
      * @Route("/party/create", name="create_party")
      * @Template("IntractoSecretSantaBundle:Party:create.html.twig")
-     * @Method("POST")
      */
     public function createAction(Request $request, PartyFormHandler $handler)
     {
+        if ($request->getMethod() != 'POST') {
+            return $this->redirectToRoute('homepage');
+        }
+
         return $this->handlePartyCreation($request, new Party(), $handler);
     }
 


### PR DESCRIPTION
Fixes issue with language switcher on the homepage. Reproducible like this:

create empty party -> form errors -> you are now at /party/create (POST only)
switch language -> 404 because page is POST only