### PR TITLE
Split dateformat for frontend/php to fix bug

### DIFF
--- a/src/Intracto/SecretSantaBundle/Form/Extension/DateTypeExtension.php
+++ b/src/Intracto/SecretSantaBundle/Form/Extension/DateTypeExtension.php
@@ -18,6 +18,7 @@ class DateTypeExtension extends AbstractTypeExtension
         $resolver->setDefaults(array(
             'widget' => 'single_text',
             'format' => 'dd-MM-yyyy',
+            'js_date_format' => 'dd-mm-yyyy',
             'append' => '<i class="icon-calendar"></i>',
             'start_date' => 'today',
             'end_date' => '31-12-2100',
@@ -47,7 +48,7 @@ class DateTypeExtension extends AbstractTypeExtension
         $view->vars['type'] = 'text';
 
         $view->vars = array_replace($view->vars, array(
-            'format' => $options['format'],
+            'js_date_format' => $options['js_date_format'],
             'start_date' => $options['start_date'],
             'end_date' => $options['end_date'],
             'highlight_currentdate' => $options['highlight_currentdate'],

--- a/src/Intracto/SecretSantaBundle/Resources/views/Form/jquery_layout.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Form/jquery_layout.html.twig
@@ -24,7 +24,7 @@
 
             {% block intracto_secret_santa_jquerydatepicker_javascript_prototype %}
             field.datepicker({
-                format: '{{ format }}',
+                format: '{{ js_date_format }}',
                 autoclose: true,
                 forceParse: true,
                 startDate: "{{ start_date }}",


### PR DESCRIPTION
Different approach and more "stable" fix for date issue from #352. Closes #352.

@tvlooy the fix from #352 broke the conversion of text input to `DateTime` object. Original issue for the fix in #200. This should be fixed now for all cases, eg the correct print in frontend and correct conversion to php object.