### PR TITLE
Change participant RU headers

### DIFF
--- a/app/Resources/translations/messages.ru.yml
+++ b/app/Resources/translations/messages.ru.yml
@@ -139,8 +139,8 @@ participant_show_base:
     headers:
         title: Подробные <span class="accent">данные о вашей вечеринке</span> Тайного Санты
         date: Дата
-#        location: ?
-        amount: Количество
+        location: Место проведения
+        amount: Сколько денег тратить на подарок
         num_people: Количество людей
         person_created_list: Автор списка
 


### PR DESCRIPTION
'Количество' in english 'count'. 'How much money to spend on a gift' in russian is more close to 'amount to spend'