### PR TITLE
Added extra travis checks

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
 cp /home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ~/xdebug.ini
 phpenv config-rm xdebug.ini || exit $? # Disable XDebug
 mkdir -p \"${BUILD_CACHE_DIR}\" || exit $? # Create build cache directory

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -16,6 +16,18 @@ if [ ! -f $BUILD_CACHE_DIR/chromedriver ]; then
     mv chromedriver $BUILD_CACHE_DIR
 fi
 
+# this checks that the YAML config files contain no syntax errors
+app/console lint:yaml app/config || exit $?
+# this checks that the Twig template files contain no syntax errors
+app/console lint:twig app/Resources/TwigBundle || exit $?
+app/console lint:twig src/Intracto/SecretSantaBundle/Resources/views || exit $?
+# this checks that the application doesn't use dependencies with known security vulnerabilities
+app/console security:check --end-point=http://security.sensiolabs.org/check_lock || exit $?
+# this checks that the composer.json and composer.lock files are valid
+composer validate --strict || exit $?
+# this checks that Doctrine's mapping configurations are valid
+app/console doctrine:schema:validate --skip-sync -vvv --no-interaction || exit $?
+
 # Run Selenium with ChromeDriver
 echo "Start selenium"
 PATH=$PATH:$BUILD_CACHE_DIR bin/selenium-server-standalone > $TRAVIS_BUILD_DIR/selenium.log 2>&1 &

--- a/app/config/config_test_travis.yml
+++ b/app/config/config_test_travis.yml
@@ -26,10 +26,6 @@ swiftmailer:
         type: file
         path: "%kernel.cache_dir%/spool"
 
-doctrine:
-    dbal:
-        dbname: "%database_name%_test"
-
 monolog:
     handlers:
         main:
@@ -38,6 +34,8 @@ monolog:
             level: error
 
 doctrine:
+    dbal:
+        dbname: "%database_name%_test"
     orm:
         entity_managers:
             default:

--- a/composer.lock
+++ b/composer.lock
@@ -2008,6 +2008,62 @@
             "time": "2017-03-26T11:55:59+00:00"
         },
         {
+            "name": "symfony/polyfill-apcu",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-apcu.git",
+                "reference": "04f62674339602def515bff4bc6901fc1d4951e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/04f62674339602def515bff4bc6901fc1d4951e8",
+                "reference": "04f62674339602def515bff4bc6901fc1d4951e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Apcu\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting apcu_* functions to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "apcu",
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2017-10-11T12:05:26+00:00"
+        },
+        {
             "name": "symfony/polyfill-intl-icu",
             "version": "v1.5.0",
             "source": {
@@ -2352,16 +2408,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v3.3.8",
+            "version": "v3.3.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "645d24a119bc7b8326bb01e7b5b696bc3be337ec"
+                "reference": "8e2b473de636a65a018b370d5e88778a260f0e33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/645d24a119bc7b8326bb01e7b5b696bc3be337ec",
-                "reference": "645d24a119bc7b8326bb01e7b5b696bc3be337ec",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/8e2b473de636a65a018b370d5e88778a260f0e33",
+                "reference": "8e2b473de636a65a018b370d5e88778a260f0e33",
                 "shasum": ""
             },
             "require": {
@@ -2374,6 +2430,7 @@
                 "psr/link": "^1.0",
                 "psr/log": "~1.0",
                 "psr/simple-cache": "^1.0",
+                "symfony/polyfill-apcu": "~1.1",
                 "symfony/polyfill-intl-icu": "~1.0",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php56": "~1.0",
@@ -2383,7 +2440,7 @@
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
-                "phpdocumentor/type-resolver": "<0.2.0",
+                "phpdocumentor/type-resolver": "<0.2.1",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
             },
             "provide": {
@@ -2445,6 +2502,7 @@
             },
             "require-dev": {
                 "cache/integration-tests": "dev-master",
+                "doctrine/annotations": "~1.0",
                 "doctrine/cache": "~1.6",
                 "doctrine/data-fixtures": "1.0.*",
                 "doctrine/dbal": "~2.4",
@@ -2456,8 +2514,7 @@
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0",
                 "predis/predis": "~1.0",
                 "sensio/framework-extra-bundle": "^3.0.2",
-                "symfony/phpunit-bridge": "~3.2",
-                "symfony/polyfill-apcu": "~1.1",
+                "symfony/phpunit-bridge": "~3.4|~4.0",
                 "symfony/security-acl": "~2.8|~3.0"
             },
             "type": "library",
@@ -2501,7 +2558,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2017-08-28T22:35:20+00:00"
+            "time": "2017-12-04T22:26:41+00:00"
         },
         {
             "name": "twig/extensions",


### PR DESCRIPTION
Some extra checks during the build to avoid small mistakes to be deployed to production. The extra checks are:

- Lint the yaml config files
- Lint the twig files
- Check for security vulnerabilities
- Validate the composer file
- Validate the doctrine mapping files

I've also updated symfony to fix an error from the security checker (see the full commit message of 
0ac0fd4 for more info) and remove a duplicate key in the travis_test config