### PR TITLE
Fixes for the upgraded travis containers

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -10,8 +10,8 @@ chromium-browser --version
 
 # Download and configure ChromeDriver
 if [ ! -f $BUILD_CACHE_DIR/chromedriver ]; then
-    # Using ChromeDriver 2.31 which supports Chrome 58-60, we're using Chromium 59
-    curl http://chromedriver.storage.googleapis.com/2.31/chromedriver_linux64.zip > chromedriver.zip
+    # Using ChromeDriver 2.33 which supports Chrome 60-62, we're using Chromium 60
+    curl http://chromedriver.storage.googleapis.com/2.33/chromedriver_linux64.zip > chromedriver.zip
     unzip chromedriver.zip
     mv chromedriver $BUILD_CACHE_DIR
 fi

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "behat/mink-extension": "^2.2",
         "behat/mink-selenium2-driver": "^1.3",
         "behat/symfony2-extension": "^2.1",
-        "se/selenium-server-standalone": "^3.4",
+        "se/selenium-server-standalone": "3.4.*",
         "friends-of-behat/performance-extension": "^1.0",
         "lakion/mink-debug-extension": "^1.2",
         "webmozart/assert": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4e6e083cd84bc61471f68c5b6fc470b",
+    "content-hash": "5faad9cb10eb72bc84f7b77ce0ac0165",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -5512,16 +5512,16 @@
         },
         {
             "name": "se/selenium-server-standalone",
-            "version": "3.5.3",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sveneisenschmidt/selenium-server-standalone.git",
-                "reference": "d3b5c43ca9c72d2abdbb3692d9cdda2dc20d9634"
+                "reference": "86da4447676b2dfd00688ac43db102cf831682af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sveneisenschmidt/selenium-server-standalone/zipball/d3b5c43ca9c72d2abdbb3692d9cdda2dc20d9634",
-                "reference": "d3b5c43ca9c72d2abdbb3692d9cdda2dc20d9634",
+                "url": "https://api.github.com/repos/sveneisenschmidt/selenium-server-standalone/zipball/86da4447676b2dfd00688ac43db102cf831682af",
+                "reference": "86da4447676b2dfd00688ac43db102cf831682af",
                 "shasum": ""
             },
             "require-dev": {
@@ -5547,7 +5547,7 @@
                 "selenium",
                 "testing"
             ],
-            "time": "2017-09-06T10:38:18+00:00"
+            "time": "2017-04-27T11:26:21+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",


### PR DESCRIPTION
Travis has upgraded their build container, so we will soon get them in our builds. This PR adds support for those new containers (newer chrome version, now 60 next will be 62), this way we support the current container and the updated one. Also locked selenium-standalone on the 3.4 version because I had issues with the newer ones.

See: https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch