### PR TITLE
Make sure the faq title links have correct anchors

### DIFF
--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -130,7 +130,7 @@ static-faq:
     body: >
         <p>This is a list of Frequently Asked Questions (FAQ) that should help you understand how this Secret Santa works.</p>
 
-        <a href="what"></a><h2>What is Secret Santa?</h2>
+        <a name="what"></a><h2>What is Secret Santa?</h2>
         <p>It’s a free online Secret Santa gift exchange organizer! Organize a Secret Santa party with friends, family or even co-workers. Each year around Christmas time people all over the world exchange gifts.
         To keep things interesting though, you can randomly assign persons to each other to give a present to one another.</p>
 
@@ -155,10 +155,10 @@ static-faq:
         <a name="manage"></a><h2>How do I manage my party / participants?</h2>
         <p>The confirmation e-mail sent to the list administrator contains a link to the list's management page.</p>
 
-        <a name="wishlist"></a><h2>Does it work with an odd number of participants?</h2>
+        <a name="odd"></a><h2>Does it work with an odd number of participants?</h2>
         <p>Yes. It doesn't matter if your party consists of an even or an odd number of participants. It is no guarantee that if person A was assigned to person B that person B is also assigned to person A. Secret Santa uses a macro to make sure everybody on the list is assigned to someone else from the list. This works randomly. For example: if John, Caroline and Steve have been added to a party, John can be assigned to Steve, Steve can be assigned to Caroline and Caroline can be assigned to John.</p>
 
-        <a href="lost"></a><h2>I lost my activation mail / url to the party.</h2>
+        <a name="lost"></a><h2>I lost my activation mail / url to the party.</h2>
         <p>If you lost your e-mail (which contains the link to the admin page or to the party where you are participating in), fill in your e-mail address on <a href="%requestForgotLink%">this page</a> and we will send you
         an overview of all the parties where you are participating in and/or the parties you have created.</p>
 
@@ -166,14 +166,14 @@ static-faq:
         <p>You can add or remove people after creating an event. On the admin page you will find a delete button and a form to add new people. There is only one catch: you can't do this if the admin excluded combinations before submitting the event.
         Allowing this would mess up the system and people might still be assigned to their excluded buddy, this made us to decide to prevent adding people if excluded combinations are present.</p>
 
-        <a href="email"></a><h2>Can I resend an email?</h2>
+        <a name="email"></a><h2>Can I resend an email?</h2>
         <p>If a participant didn't receive the e-mail for their buddy, the list owner can resend the e-mail for that participant from the management page. You can also change someone's e-mail address from the same page and resend the e-mail.<br><br>
         If you didn't receive the activation e-mail, check your spam folder. You should receive this email within a few minutes. If you still didn't receive the activation e-mail, you will have to start all over again by creating a new list.</p>
 
-        <a href="combinations"></a><h2>Can I look into all combinations / wishlists?</h2>
+        <a name="combinations"></a><h2>Can I look into all combinations / wishlists?</h2>
         <p>You can optionally see the combinations and wishlists on the management page. There are buttons for that, you won't see this by default. If you want to share this information with all the participants you will have to share the URL yourself.</p>
 
-        <a href="delete"></a><h2>Can I delete my list?</h2>
+        <a name="delete"></a><h2>Can I delete my list?</h2>
         <p>Sure you can. Just go to your list management page and use the delete option. All your list data will be permanently removed from our system.</p>
 
         <a name="who"></a><h2>Who are you?</h2>
@@ -202,7 +202,7 @@ static-faq:
         We might use it to buy pizza and drinks for one of our hackdays. Or we might pay professional translators to add more languages to our Secret Santa Organizer. Or it could be something else.
         By the way, we are still looking for Russian, Indian, Japanese, ... translations. If you can help us with this (for free), please contact us.</p>
 
-        <a href="questions"></a><h2>Other questions</h2>
+        <a name="questions"></a><h2>Other questions</h2>
         <p>Any other questions, concerns, or comments? Contact us by e-mail:<br/>info@secretsantaorganizer.com</p>
     create_new_list: Create a new Secret Santa list!
 

--- a/app/Resources/translations/messages.fr.yml
+++ b/app/Resources/translations/messages.fr.yml
@@ -105,7 +105,7 @@ static-faq:
     title: Questions fréquemment posées
     body: >
         <p>Ceci est une liste de questions fréquemment posées (FAQ) qui devrait vous aider à comprendre le fonctionnement de Secret Santa.</p>
-        <a href="what"></a><h2>Qu'est-ce que Secret Santa?</h2>
+        <a name="what"></a><h2>Qu'est-ce que Secret Santa?</h2>
         <p>Secret Santa est un organiseur en ligne gratuit d'échange de cadeaux ! Organisez une Secret Santa party avec vos amis, votre famille ou vos collègues. Chaque année, durant la période de Noël, les gens du monde entier s'échangent des cadeaux.</p>
         <p>Afin de garder les choses intéressantes, vous pouvez assigner au hasard une personne à une autre afin qu'elles offrent un présent aux autres.</p>
         <a name="how"></a><h2>Comment ça fonctionne?</h2>
@@ -124,12 +124,12 @@ static-faq:
         <a name="changes"></a><h2>Puis-je ajouter ou retirer quelqu'un?</h2>
         <p>Il est possible d'ajouter ou retirer une personne après avoir créé votre événement. Sur votre page d'administration vous trouverez un bouton avec lequel vous pourrez retirer quelqu'un ainsi qu'un formulaire qui vous permettra d'ajouter quelqu'un.
         Exception: si l'administrateur a exclu des combinaisons avant de créer l'événement, il ne sera pas possible d'ajouter ou de retirer des participants. Si nous le permettons, on court le risque que des combinaisons exclus se produisent, c'est pour ça qu'on a decidé de ne pas permettre cette fonctionalité en ce cas.</p>
-        <a href="email"></a><h2>Puis-je renvoyer un e-mail?</h2>
+        <a name="email"></a><h2>Puis-je renvoyer un e-mail?</h2>
         <p>Si un participant n'a pas reçu l'e-mail contenant le nom de la personne à qui il doit offrir un cadeau, l'administrateur peut renvoyer un e-mail pour ce participant depuis la page d'administration. Vous pouvez également changer l'adresse e-mail d'un participant à partir de cette même page et lui renvoyer un e-mail.<br><br>
         Si vous ne recevez pas l'e-mail d'activation, vérifier vos courriers indésirables (SPAM). Vous devriez recevoir cet e-mail après peu de temps. Si vous n'avez toujours pas reçu l'e-mail d'activation, vous devrez alors créer à nouveau votre liste.</p>
-        <a href="combinations"></a><h2>Puis-je voir toutes les combinaisons / listes de souhaits?</h2>
+        <a name="combinations"></a><h2>Puis-je voir toutes les combinaisons / listes de souhaits?</h2>
         <p>Vous pouvez demander à recevoir toutes les attributions / listes de souhaits depuis la page d'administration de votre liste. Mais cela va gâcher le secret de votre Secret Santa party. C'est pourquoi nous avons ajouté un indicateur informant les participants sur le fait que l'administrateur connaît toutes les combinaisons / listes de souhaits lorsqu'il effectue cette demande.</p>
-        <a href="delete"></a><h2>Puis-je supprimer ma liste?</h2>
+        <a name="delete"></a><h2>Puis-je supprimer ma liste?</h2>
         <p>Bien sûr que vous pouvez. Rendez-vous sur la page d'administration de votre liste et utilisez l'option de suppression. Toutes les données liées à votre liste seront supprimées de notre système.</p>
         <a name="who"></a><h2>Qui êtes-vous?</h2>
         <p>Nous sommes une poignée de <a href="https://github.com/Intracto/SecretSanta/graphs/contributors" target="_blank" rel="noopener noreferrer">développeurs</a>, designers, frontenders, SEO's et marketers. Secret Santa est l'un de nos projets. Nous sommes sponsorisés par notre employeur <a href="http://www.intracto.com/" target="_blank">Intracto digital agency</a>. Notre but est de mettre en place un organiseur d'échange de cadeaux à la fois simple et pratique. Nous profitons également de ce projet pour faire des expériences. Notre objectif principal est qu'il soit utilisé par tous. Au plus il y a de monde, mieux c'est ! ;-)</p>
@@ -141,7 +141,7 @@ static-faq:
         <p>Chaque octet de ce site Internet est rendu Open Source sur <a href="https://github.com/Intracto/SecretSanta" target="_blank" rel="noopener noreferrer">GitHub</a>. Le projet est disponible sous une <a href="https://github.com/Intracto/SecretSanta/blob/master/LICENSE" target="_blank">licence ISC</a>, très permissive. Vous pouvez donc copier ce projet et, par exemple, créer votre propre Secret Santa. Ou participer à ce projet en soumettant votre contribution (pull request). Si vous souhaitez un changement ou une nouvelle fonction, ajoutez-la simplement.</p>
         <a name="ads"></a><h2>A propos des publicités</h2>
         <p>Nous avons des publicités Google ici et là afin de couvrir certaines de nos dépenses. Par exemple, l'hébergement, le nom de domaine, etc. Nous faisons tout nous-mêmes gratuitement et l'argent que nous collectons est réinjecté dans le projet. Il pourrait être utilisé afin d'acheter des pizzas et boissons pour l'un de nos hackdays. Ou il pourrait encore servir à payer un traducteur afin d'ajouter de nouvelles langues à notre Secret Santa Organizer. Ou d'autres choses encore. Au fait, nous recherchons toujours des traductions en russe, japonais... Si vous pouvez nous aider (gratuitement), merci de bien vouloir nous contacter.</p>
-        <a href="questions"></a><h2>Autres questions</h2>
+        <a name="questions"></a><h2>Autres questions</h2>
         <p>D'autres questions, préoccupations ou commentaires ? Contactez-nous par:<br/>info@secretsantaorganizer.com</p>
     create_new_list: Créez une nouvelle liste Secret Santa !
 

--- a/app/Resources/translations/messages.nl.yml
+++ b/app/Resources/translations/messages.nl.yml
@@ -127,7 +127,7 @@ static-faq:
     body: >
         <p>Dit is een lijst met vaak gestelde vragen (Frequently Asked Questions / FAQ) die je kunnen helpen om deze Secret Santa beter te begrijpen.</p>
 
-        <a href="what"></a><h2>Wat is Secret Santa?</h2>
+        <a name="what"></a><h2>Wat is Secret Santa?</h2>
         <p>Het is een gratis online Secret Santa geschenkuitwisselings-organizer! Ieder jaar wisselen wereldwijd mensen tijdens de kerstperiode wereldwijd geschenken uit.
         Om het voor iedereen wat spannender te maken, kan je mensen willekeurig toewijzen om voor elkaar geschenkjes te kopen.</p>
 
@@ -163,7 +163,7 @@ static-faq:
         <a name="odd"></a><h2>Werkt Secret Santa ook met een oneven aantal deelnemers?</h2>
         <p>Ja. Het maakt niet uit of je feestje bestaat uit een even of oneven aantal deelnemers. Het is namelijk niet zo dat als persoon A is toegekend aan persoon B dat persoon B ook is toegekend aan persoon A. Secret Santa gebruikt een macro om zeker te zijn dat iedereen op de lijst is toegekend aan iemand anders van de lijst. Dit werkt willekeurig. Voorbeeld: als John, Caroline en Steve zijn toegevoegd aan een feestje, dan kan John toegekend zijn aan Steve. Steve kan toegekend zijn aan Caroline. Caroline kan toegekend zijn aan John.</p>
 
-        <a href="lost"></a><h2>Ik ben mijn bevestigingsmail / link naar het feestje kwijt.</h2>
+        <a name="lost"></a><h2>Ik ben mijn bevestigingsmail / link naar het feestje kwijt.</h2>
         <p>Als je de bevestigingsmail kwijt bent (deze bevat de link naar de beheerpagina van de lijst of naar het feestje waaraan je meedoet) is de wereld nog niet ontploft. Geef op <a href="%requestForgotLink%">deze pagina</a> jouw mailadres in en we sturen je een mail met een
         overzicht van alle feestjes waaraan je meedoet en/of die je hebt aangemaakt.</p>
 
@@ -171,14 +171,14 @@ static-faq:
         <p>Je kan deelnemers toevoegen of verwijderen na het aanmaken van je evenement. Op de beheerpagina kan je een knop vinden om deelnemers te verwijderen en is er een formulier waarmee een deelnemer toegevoegd kan worden.
         Er is slecht één uitzondering: je kan geen deelnemers toevoegen of verwijderen wanneer de beheerder combinaties heeft uitgesloten bij het aanmaken van het evenement. Indien we dit zouden toelaten, bestaat de kans dat uitgesloten combinaties toch zouden voorvallen, daarom hebben we besloten om dit niet toe te laten.</p>
 
-        <a href="email"></a><h2>Kan ik een e-mail opnieuw versturen?</h2>
+        <a name="email"></a><h2>Kan ik een e-mail opnieuw versturen?</h2>
         <p>Als een deelnemer geen e-mail heeft ontvangen kan de lijstbeheerder de e-mail opnieuw versturen vanaf de beheerpagina. Je kan ook het e-mailadres van een deelnemer wijzigen vanaf dezelfde pagina en de mail opnieuw versturen.<br><br>
         Als je geen bevestigingsmail hebt ontvangen, controleer dan je spam folder. Je zou de e-mail binnen enkele minuten moeten ontvangen. Nog altijd geen bevestigingsmail ontvangen? Maak dan een nieuwe lijst aan.</p>
 
-        <a href="combinations"></a><h2>Kan ik alle combinaties / verlanglijsten opvragen?</h2>
+        <a name="combinations"></a><h2>Kan ik alle combinaties / verlanglijsten opvragen?</h2>
         <p>Je kan de combinaties / verlanglijsten opvragen vanaf de beheerpagina. Omdat er dan niet veel "secret" meer aan is, zullen alle deelnemers zien dat de beheerder al dan niet de combinaties / verlanglijsten heeft bekeken :-)</p>
 
-        <a href="delete"></a><h2>Kan ik mijn lijst verwijderen?</h2>
+        <a name="delete"></a><h2>Kan ik mijn lijst verwijderen?</h2>
         <p>Uiteraard kan dat, ga naar de beheerpagina van de lijst en gebruik de verwijderoptie. Al de gegevens met betrekking tot deze lijst zullen permanent uit ons systeem verwijderd worden.</p>
 
         <a name="who"></a><h2>Wie zijn jullie?</h2>
@@ -207,7 +207,7 @@ static-faq:
         Zo hebben we eurolingers voor pizza en drank op onze hackdays maar ook voor professionele vertalers waarmee we dan weer verder de wereld veroveren met Secret Santa Organizer.
         We zoeken trouwens nog Russische, Indische, Japanse, ... vertalingen. Als je ons hier (gratis) bij kan helpen, neem dan contact met ons op.</p>
 
-        <a href="questions"></a><h2>Andere vragen</h2>
+        <a name="questions"></a><h2>Andere vragen</h2>
         <p>Heb je andere vragen, bedenkingen of opmerkingen? Contacteer ons dan via e-mail:<br/>info@secretsantaorganizer.com</p>
     create_new_list: Stel een nieuwe Secret Santa lijst op!
 

--- a/app/Resources/translations/messages.no.yml
+++ b/app/Resources/translations/messages.no.yml
@@ -120,7 +120,7 @@ static-faq:
     body: >
         <p>Nedenfor følger en liste med ofte stilte spørsmål (FAQ) om hvordan Secret Santa fungerer.</p>
 
-        <a href="what"></a><h2>Hva er Secret Santa?</h2>
+        <a name="what"></a><h2>Hva er Secret Santa?</h2>
         <p>Et gratis online "hemmelig venn" program for å organisere gaveutveksling! Arranger et juleselskap med "hemmelig venn"/Secret Santa med venner, familie eller kolleger. HVert år rundt juletider, over hele verden, gir man hverandre gaver.
         For å gjøre ting mer interessant kan du tildele andre en tilfeldig "venn" eller "nisse" å gi presanger til.</p>
 
@@ -142,21 +142,21 @@ static-faq:
         <a name="manage"></a><h2>Hvordan holder jeg oversikt over festen/deltagerne?</h2>
         <p>Bekreftelsen sendes til administratoren, og den inneholder også link til en administrasjonsside hvor du kan gjøre endringer.</p>
 
-        <a href="lost"></a><h2>Jeg mistet bekreftelseseposten.</h2>
+        <a name="lost"></a><h2>Jeg mistet bekreftelseseposten.</h2>
         <p>Hvis du har mistet e-posten med bekreftelseslinken i (som også inneholder linken til administrasjonssiden), skriv inn administratorens e-post <a href="%requestForgotLink%">her</a> og vi sender deg linken på nytt.</p>
 
         <a name="changes"></a><h2>Kan jeg legge til eller fjerne personer fra listen?</h2>
         <p>Du kan legge til eller fjerne personer etter arrangementet er opprettet. På admin-siden finner du en slett-knapp og et skjema for å legge til nye personer. Det er bare én hake ved det: Du kan ikke gjøre dette dersom administrator har forhindret enkelte kombinasjoner av personer før arrangementet ble opprettet.
         Dette fordi det skaper unødvendig mye krøll i systemet, og det gjør det i tillegg vanskelig å legge til nye personer.</p>
 
-        <a href="email"></a><h2>Kan jeg sende eposter på nytt?</h2>
+        <a name="email"></a><h2>Kan jeg sende eposter på nytt?</h2>
         <p>Hvis en deltager ikke mottok e-posten første gangen, kan administrator sende en ny e-post til denne personen. Du kan også endre deltagernes epostadresser på den samme siden og sende e-posten på nytt til denne adressen.<br><br>
         Hvis du ikke mottok e-posten med link til å bekrefte arrangementet, sjekk søppelpost i innboksen din. Du skal ha mottat e-posten innen et par minutter. Har du fortsatt ikke mottat denne eposten, må du dessverre opprette en ny liste.</p>
 
-        <a href="combinations"></a><h2>Kan jeg få oversikt over kombinasjoner/ønskelister?</h2>
+        <a name="combinations"></a><h2>Kan jeg få oversikt over kombinasjoner/ønskelister?</h2>
         <p>Du kan hente kombinasjonen av nisser/ønskelister fra admin-siden. Men det ødelegger på en måte poenget med "hemmelig nisse". Derfor har vi lagt til en indikator til alle deltagerne som viser når kombinasjonen av nisser/ønskelister har blitt hentet av administrator :-)</p>
 
-        <a href="delete"></a><h2>Kan jeg slette listen min?</h2>
+        <a name="delete"></a><h2>Kan jeg slette listen min?</h2>
         <p>Selvfølgelig, bare gå til admin-siden og velg slett-knappen. All informasjon fra din liste vil bli slettet fra våre systemer.</p>
 
         <a name="who"></a><h2>Hvem er dere?</h2>
@@ -185,7 +185,7 @@ static-faq:
         Innimellom hender det selvfølgelig at vi spanderer pizza og drinker på koderne våre. Eller vi får profesjonelle oversettere til å oversette nettsiden til andre språk. Eller vi bruker pengene på noe annet.
         Forresten, vi ser fortsatt etter noen til å oversette nettsiden til russisk, japansk, indisk.... Hvis du vil hjelpe oss med dette (gratis), vennligst kontakt oss!</p>
 
-        <a href="questions"></a><h2>Andre spørsmål?</h2>
+        <a name="questions"></a><h2>Andre spørsmål?</h2>
         <p>Har du andre spørsmål, bekymringer, eller kommentarer? Kontakt oss per e-post:<br/>info@secretsantaorganizer.com</p>
     create_new_list: Opprett en ny Secret Santa-liste!
 

--- a/app/Resources/translations/messages.pt.yml
+++ b/app/Resources/translations/messages.pt.yml
@@ -113,7 +113,7 @@ static-faq:
     body: >
         <p>Essa é a lista de Perguntas Frequentes (FAQ) e vai te ajudar a entender como o Secret Santa, ou Amigo Secreto, funciona.</p>
 
-        <a href="what"></a><h2>O que é Secret Santa?</h2>
+        <a name="what"></a><h2>O que é Secret Santa?</h2>
         <p>É um <strong>organizador de troca de presentes</strong> online <strong>gratuito</strong>! Organize uma festa com Amigo Oculto com seus amigos, sua família ou até com seus colegas. Após ter recebido um e-mail do Secret Santa Organizer, você pode adicionar sua própria <strong>lista de desejos</strong>, que será encaminhada para o seu Secret Santa.</p>
         <p>Todos os anos, pessoas no mundo inteiro trocam presentes durante o período de Natal.<br/> Para deixar esse momento ainda mais memorável, você pode fazer com que <strong>pessoas escolhidas arbitrariamente</strong> comprem presentes umas para as outras.</p>
 
@@ -133,7 +133,7 @@ static-faq:
         <a name="manage"></a><h2>Como posso gerenciar meu evento ou participantes?</h2>
         <p>O e-mail de confirmação mandado ao operador da lista contém um link para a página de Gerenciamento da Lista.</p>
 
-        <a href="lost"></a><h2>Eu perdi meu e-mail de ativação.</h2>
+        <a name="lost"></a><h2>Eu perdi meu e-mail de ativação.</h2>
         <p>Se você perdeu seu e-mail de ativação (que contém o link para gerenciar sua lista), entre em contato conosco pelo e-mail do proprietário da lista e nós lhe reenviaremos o link.
         <a href="https://github.com/Intracto/SecretSanta/issues/93" target="_blank" rel="noopener noreferrer">Lá você encontra uma solicitação de recurso</a> para automatizar este recurso.</p>
 
@@ -141,14 +141,14 @@ static-faq:
         <p>Ao criar um evento, todos os participantes são automaticamente sorteados e atribuídos uns aos outros. Dessa forma, é difícil reverter o processo adicionando ou removendo pessoas depois de tê-las sorteado. Isso envolveria mudar todos os pares, causando transtornos e confusões indesejáveis.
         Sugerimos que use a página de gerenciamento da sua lista para que você resolva seus problemas manualmente.</p>
 
-        <a href="email"></a><h2>Posso reenviar um email?</h2>
+        <a name="email"></a><h2>Posso reenviar um email?</h2>
         <p>Se um dos participantes não recebeu o e-mail contendo seu Amigo Secreto, o proprietário da lista poderá reenviar o e-mail para este participante pela sua página de gerenciamento. Você também pode mudar o endereço de e-mail de alguém e reenviá-lo por essa mesma página.<br><br>
         Se você não recebeu seu e-mail de ativação ou validação, verifique sua Pasta de Spams ou Lixo. Este email deve ser recebido dentro de alguns minutos depois de um novo evento ser criado. Se, depois de muitos minutos, você ainda não recebeu o e-mail de ativação ou validação e ele também não estiver nas pastas de Spam ou Lixo, isso é sinal de que a criação do novo evento falhou e você deverá tentar criar um novo evento novamente.</p>
 
-        <a href="combinations"></a><h2>Posso ver todas as combinações?</h2>
+        <a name="combinations"></a><h2>Posso ver todas as combinações?</h2>
         <p>Você pode pedir por sua lista de combinações pela sua página de Gerenciamento. Tenha em mente, contudo, que isso estraga a parte "secreta” da brincadeira do Amigo Secreto. Pensando nisso, nós adicionamos um indicador nas páginas de todos os participantes da sua lista. Esse indicador mostra quando o proprietário viu as combinações :-)</p>
 
-        <a href="delete"></a><h2>Posso deletar minha lista?</h2>
+        <a name="delete"></a><h2>Posso deletar minha lista?</h2>
         <p>É claro que pode! Na sua página de gerenciamento de listas você encontra a opção "deletar minha lista do Secret Santa". Toda a sua lista será removida permanentemente do nosso sistema.</p>
 
         <a name="who"></a><h2>Quem são vocês?</h2>
@@ -170,7 +170,7 @@ static-faq:
         Talvez tenhamos comprado umas pizzas e bebidas quando precisávamos fazer hora extra tentando arrumar algo no projeto. É possível que tenhamos desembolsado uma pequena quantia pagando tradutores para adicionar Secret Santa Organizer em outras línguas.
         Aliás, ainda estamos buscando tradutores voluntários para termos Secret Santas em Russo, Indiano, Japonês... Se você quiser nos ajudar (de graça) ou conhece alguém que pode, por favor, entre em contato.</p>
 
-        <a href="questions"></a><h2>Outras perguntas</h2>
+        <a name="questions"></a><h2>Outras perguntas</h2>
         <p>Se você tiver qualquer outra pergunta, sugestão ou reclamações, apenas entre em contato conosco por e-mail:<br/>info@secretsantaorganizer.com</p>
     create_new_list: Montar uma nova lista do Secret Santa!
 
@@ -254,7 +254,7 @@ participant_communication-send_message:
     feedback:
         success: Seu email foi enviado! Enviamos nossos gnomos para entregá-lo!
         error: Infelizmente nós não conseguimos enviar sua mensagem. Por favor tente novamente mais tarde!
-        error_in_form: Existe algum erro na sua entrada. Por favor verifique sua entrada e tente novamente! 
+        error_in_form: Existe algum erro na sua entrada. Por favor verifique sua entrada e tente novamente!
 # Participant/unsubscribe.html.twih
 participant_unsubscribe:
     title: Cancelar a subscrição de emails


### PR DESCRIPTION
The way we can easily link to specific parts of the faq. Ex. https://secretsantaorganizer.com/faq#manage