### PR TITLE
only validate relevant data

### DIFF
--- a/src/Intracto/SecretSantaBundle/Controller/Party/ManagementController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Party/ManagementController.php
@@ -62,7 +62,7 @@ class ManagementController extends Controller
     public function updateAction(Request $request, Party $party)
     {
         $party->setConfirmed(true);
-        $updatePartyDetailsForm = $this->createForm(UpdatePartyDetailsType::class, $party);
+        $updatePartyDetailsForm = $this->createForm(UpdatePartyDetailsType::class, $party, ['validation_groups' => 'Party']);
         $updatePartyDetailsForm->handleRequest($request);
 
         if ($updatePartyDetailsForm->isSubmitted() && $updatePartyDetailsForm->isValid()) {

--- a/src/Intracto/SecretSantaBundle/Controller/WishlistController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/WishlistController.php
@@ -32,7 +32,7 @@ class WishlistController extends AbstractController
      */
     public function updateAction(Request $request, Participant $participant, WishlistFormHandler $handler) : JsonResponse
     {
-        $wishlistForm = $this->createForm(WishlistType::class, $participant);
+        $wishlistForm = $this->createForm(WishlistType::class, $participant, ['validation_groups' => 'WishlistItem']);
 
         if ($handler->handle($wishlistForm, $request)) {
             return new JsonResponse(['success' => true, 'message' => 'Added!']);


### PR DESCRIPTION
Sometimes there is an error when party admins send a party update, or when a participant updates his/her wishlist.

The problem is that it validates the complete object tee, including data that is not changed. Eg: update party -> all participants are validated. Eg: update a wishlist -> participant, party and participants are validated.

Because we have a validator on the participant to check if he/she is blacklisted, it is possible that suddenly a participant will not validate anymore.

I think that validator is not in the right place there, let that be clear.

But as a good workaround I think just limiting the form validation to the data that actually changed is a good fix here.