### PR TITLE
#362: use separate hash for exposing wishlists

### DIFF
--- a/src/Intracto/Behat/DataFixtures/LoadPartyData.php
+++ b/src/Intracto/Behat/DataFixtures/LoadPartyData.php
@@ -23,6 +23,7 @@ class LoadPartyData implements FixtureInterface
         $party = new Party(false);
 
         $party->setListurl(FeatureContext::STARTED_PARTY_URL_TOKEN);
+        $party->setWishlistsurl(FeatureContext::CREATED_PARTY_WISHLISTS_URL_TOKEN);
         $party->setAmount(100);
 
         $eventDate = (new \DateTime())->add(new \DateInterval('P2M'));
@@ -102,6 +103,7 @@ class LoadPartyData implements FixtureInterface
         $party = new Party(false);
 
         $party->setListurl(FeatureContext::CREATED_PARTY_URL_TOKEN);
+        $party->setWishlistsurl(FeatureContext::CREATED_PARTY_WISHLISTS_URL_TOKEN);
         $party->setAmount(90);
 
         $eventDate = (new \DateTime())->add(new \DateInterval('P1M14D'));

--- a/src/Intracto/Behat/Features/Context/FeatureContext.php
+++ b/src/Intracto/Behat/Features/Context/FeatureContext.php
@@ -13,6 +13,7 @@ class FeatureContext extends RawMinkContext
     use KernelDictionary;
 
     const STARTED_PARTY_URL_TOKEN = 'jux1a80pnu8s48ko8ckskco08s0wc4g';
+    const CREATED_PARTY_WISHLISTS_URL_TOKEN = 'k81skwgcsu8c0x48apc8n80ujo4kso0';
     const CREATED_PARTY_URL_TOKEN = 'mup6g475ok08ss8gc4wgg8ogcwkw08s';
 
     const PARTICIPANT_URL_TOKEN = 'hkn7ycdnqhskg4g8g0c08wkkgsoscws';

--- a/src/Intracto/SecretSantaBundle/Command/FixMissingPartyWishlistsurlCommand.php
+++ b/src/Intracto/SecretSantaBundle/Command/FixMissingPartyWishlistsurlCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Intracto\SecretSantaBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FixMissingPartyWishlistsurlCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('intracto:fix:missing_party_wishlists')
+            ->setDescription('TEMPORARY');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var \Doctrine\DBAL\Driver\Connection $dbal */
+        $conn = $this->getContainer()->get('doctrine.dbal.default_connection');
+        $parties = $conn->query('select id from party where wishlists_url = ""');
+        $stmt = $conn->prepare('update party set wishlists_url = :wishlists_url where id = :id');
+        foreach ($parties as $party) {
+            $stmt->bindValue('id', $party['id']);
+            $stmt->bindValue('wishlists_url', base_convert(sha1(uniqid(mt_rand(), true)), 16, 36));
+            $stmt->execute();
+            echo '.';
+        }
+        echo "\n\nDONE\n";
+    }
+}

--- a/src/Intracto/SecretSantaBundle/Controller/WishlistController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/WishlistController.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class WishlistController extends AbstractController
 {
     /**
-     * @Route("/wishlists/show/{listurl}", name="wishlist_show_all")
+     * @Route("/wishlists/show/{wishlistsurl}", name="wishlist_show_all")
      * @Template("IntractoSecretSantaBundle:Wishlist:showAll.html.twig")
      * @Method("GET")
      */

--- a/src/Intracto/SecretSantaBundle/Entity/Party.php
+++ b/src/Intracto/SecretSantaBundle/Entity/Party.php
@@ -17,6 +17,12 @@ class Party
     /** @var string */
     private $listurl;
 
+    /**
+     * The URL that is used to expose the wishlists for all participants of the party
+     * @var string
+     */
+    private $wishlistsurl;
+
     /** @var string */
     private $message;
 
@@ -78,6 +84,7 @@ class Party
         }
 
         $this->listurl = base_convert(sha1(uniqid(mt_rand(), true)), 16, 36);
+        $this->wishlistsurl = base_convert(sha1(uniqid(mt_rand(), true)), 16, 36);
         $this->creationdate = new \DateTime();
     }
 
@@ -107,6 +114,26 @@ class Party
     public function getListurl()
     {
         return $this->listurl;
+    }
+
+    /**
+     * @param string $wishlistsurl
+     *
+     * @return Party
+     */
+    public function setWishlistsurl($wishlistsurl)
+    {
+        $this->wishlistsurl = $wishlistsurl;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getWishlistsurl()
+    {
+        return $this->wishlistsurl;
     }
 
     /**

--- a/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Participant.orm.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Participant.orm.xml
@@ -41,7 +41,7 @@
         <field name="viewdate" column="view_date" type="datetime" nullable="true"/>
         <field name="openEmailDate" column="open_email_date" type="datetime" nullable="true"/>
         <field name="viewReminderSentTime" column="view_reminder_sent" type="datetime" nullable="true"/>
-        <field name="url" column="url" type="string" length="255" nullable="true"/>
+        <field name="url" column="url" type="string" length="50" unique="true"/>
 
         <one-to-many field="wishlistItems" target-entity="WishlistItem" mapped-by="participant">
             <order-by>

--- a/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Party.orm.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Party.orm.xml
@@ -16,7 +16,8 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="listurl" column="list_url" type="string" length="255"/>
+        <field name="listurl" column="list_url" type="string" length="50" unique="true"/>
+        <field name="wishlistsurl" column="wishlists_url" type="string" length="50"/> <!-- Todo after intracto:fix:missing_party_wishlists: unique="true" -->
         <field name="message" column="message" type="text" nullable="true"/>
         <field name="creationdate" column="creation_date" type="datetime"/>
         <field name="sentdate" column="sent_date" type="datetime" nullable="true"/>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
@@ -214,7 +214,7 @@
             <a id="btn_expose_matches" href="{{ path('expose_participants', { 'listurl': party.listurl }) }}" class="btn btn-warning manage_btn manage_btn_middle manage_btn_link">
                 <i class="fa fa-eye"></i> {{ 'party_manage_valid.btn.expose'|trans }}
             </a>
-            <a id="btn_expose_wishlists" class="btn btn-warning manage_btn manage_btn_link" href="{{ path('wishlist_show_all', { 'listurl': party.listurl }) }}">
+            <a id="btn_expose_wishlists" class="btn btn-warning manage_btn manage_btn_link" href="{{ path('wishlist_show_all', { 'wishlistsurl': party.wishlistsurl }) }}">
                 <i class="fa fa-eye"></i> {{ 'party_manage_valid.btn.expose_wishlists'|trans }}
             </a>
         {% endif %}


### PR DESCRIPTION
Todo after deploy:
  - run intracto:fix:missing_party_wishlists
  - open new PR to:
    - remove FixMissingPartyWishlistsurlCommand
    - add unique to Party.orm.xml (see todo)
