### PR TITLE
Use new autowire features to simplify the service config

### DIFF
--- a/app/config/legacy_aliases.yml
+++ b/app/config/legacy_aliases.yml
@@ -15,7 +15,7 @@ services:
     intracto_secret_santa.query.wishlist_mail: '@Intracto\SecretSantaBundle\Query\WishlistMailQuery'
     intracto_secret_santa.query.bounce: '@Intracto\SecretSantaBundle\Query\BounceQuery'
 
-    intracto_secret_santa.repository.party: '@Intracto\SecretSantaBundle\Entity\PartyRepository'
-    intracto_secret_santa.repository.participant: '@Intracto\SecretSantaBundle\Entity\ParticipantRepository'
+    intracto_secret_santa.repository.party: '@Intracto\SecretSantaBundle\Repository\PartyRepository'
+    intracto_secret_santa.repository.participant: '@Intracto\SecretSantaBundle\Repository\ParticipantRepository'
 
     cache: '@Doctrine\Common\Cache\ApcuCache'

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -6,6 +6,8 @@ services:
         autowire: true
         autoconfigure: true
         public: false
+        bind:
+            $geoIpDbPath: '%geo_ip_db_path%'
 
     Intracto\SecretSantaBundle\:
         resource: '../../src/Intracto/SecretSantaBundle/*'
@@ -31,28 +33,8 @@ services:
         tags:
           - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\DateType }
 
-    Intracto\SecretSantaBundle\Entity\PartyRepository:
-        class: Doctrine\ORM\EntityRepository
-        factory: doctrine.orm.entity_manager:getRepository
-        arguments:
-            - 'IntractoSecretSantaBundle:Party'
-
-    Intracto\SecretSantaBundle\Entity\ParticipantRepository:
-        class: Doctrine\ORM\EntityRepository
-        factory: doctrine.orm.entity_manager:getRepository
-        arguments:
-            - 'IntractoSecretSantaBundle:Participant'
-
-    Intracto\SecretSantaBundle\Command\EnrichParticipantInfoCommand:
-        arguments:
-            $geoIpDbPath: '%geo_ip_db_path%'
-
-    Intracto\SecretSantaBundle\Service\ParticipantService:
-        arguments:
-            $geoIpDbPath: '%geo_ip_db_path%'
-
     Doctrine\Common\Cache\ApcuCache: ~
     Twig\Extensions\TextExtension: ~
     Twig\Extensions\IntlExtension: ~
-    
+
     Symfony\Component\Form\FormRendererInterface: '@twig.form.renderer'

--- a/src/Intracto/SecretSantaBundle/Command/EnrichParticipantInfoCommand.php
+++ b/src/Intracto/SecretSantaBundle/Command/EnrichParticipantInfoCommand.php
@@ -6,7 +6,7 @@ use Symfony\Component\Console\Command\Command;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Intracto\SecretSantaBundle\Entity\ParticipantRepository;
+use Intracto\SecretSantaBundle\Repository\ParticipantRepository;
 use GeoIp2\Database\Reader;
 use GeoIp2\Exception\AddressNotFoundException;
 

--- a/src/Intracto/SecretSantaBundle/Controller/Participant/DumpParticipantsController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Participant/DumpParticipantsController.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Intracto\SecretSantaBundle\Controller\Participant;
 
-use Intracto\SecretSantaBundle\Entity\ParticipantRepository;
+use Intracto\SecretSantaBundle\Repository\ParticipantRepository;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;

--- a/src/Intracto/SecretSantaBundle/Repository/ParticipantRepository.php
+++ b/src/Intracto/SecretSantaBundle/Repository/ParticipantRepository.php
@@ -1,11 +1,18 @@
 <?php
 
-namespace Intracto\SecretSantaBundle\Entity;
+namespace Intracto\SecretSantaBundle\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Intracto\SecretSantaBundle\Entity\Participant;
 
-class ParticipantRepository extends EntityRepository
+class ParticipantRepository extends ServiceEntityRepository
 {
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Participant::class);
+    }
+
     /**
      * @param \DateTime $startDate
      *

--- a/src/Intracto/SecretSantaBundle/Repository/PartyRepository.php
+++ b/src/Intracto/SecretSantaBundle/Repository/PartyRepository.php
@@ -1,11 +1,18 @@
 <?php
 
-namespace Intracto\SecretSantaBundle\Entity;
+namespace Intracto\SecretSantaBundle\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Intracto\SecretSantaBundle\Entity\Party;
 
-class PartyRepository extends EntityRepository
+class PartyRepository extends ServiceEntityRepository
 {
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Party::class);
+    }
+
     public function findAllAdminParties($email)
     {
         $qb = $this->_em->createQueryBuilder();

--- a/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Participant.orm.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Participant.orm.xml
@@ -5,7 +5,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                    https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
 
-    <entity name="Intracto\SecretSantaBundle\Entity\Participant" table="participant" repository-class="Intracto\SecretSantaBundle\Entity\ParticipantRepository">
+    <entity name="Intracto\SecretSantaBundle\Entity\Participant" table="participant" repository-class="Intracto\SecretSantaBundle\Repository\ParticipantRepository">
 
         <indexes>
             <index name="participant_url" columns="url"/>

--- a/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Party.orm.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Party.orm.xml
@@ -5,7 +5,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                    https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
 
-    <entity name="Intracto\SecretSantaBundle\Entity\Party" table="party" repository-class="Intracto\SecretSantaBundle\Entity\PartyRepository">
+    <entity name="Intracto\SecretSantaBundle\Entity\Party" table="party" repository-class="Intracto\SecretSantaBundle\Repository\PartyRepository">
 
         <indexes>
             <index name="list_url" columns="list_url"/>


### PR DESCRIPTION
- Use local service binding to remove some extra service config with duplicate parameters.
- Use the "ServiceEntityRepository" class to extend repositories from (introduced in doctrineBundle 1.8.0+) to avoid explicitly defining repositories in the service config