### PR TITLE
Don't fix files in var dir

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,3 +2,7 @@ preset: symfony
 
 disabled:
     - yoda_style
+
+finder:
+    exclude:
+        - "var"


### PR DESCRIPTION
These are files we don't "own" and cache files. So don't fix those. For example on each `composer update` the `SymfonyRequirements` file will change codestyle to the default.