### PR TITLE
Pretty output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 all:
 	@echo "usage: make"
-	@echo "        [deploy]    update the PROD env"
-	@echo "        [db-backup] backup DEV database"
+	@echo "  [deploy]        update the PROD env"
+	@echo "  [deploy-debug]  update the PROD env, show debug output"
+	@echo "  [db-backup]     backup DEV database"
 
 
 deploy:
 	ssh secretsanta@secretsantaorganizer.com 'bash -s' < deploy.sh
 
 
+deploy-debug:
+	ssh secretsanta@secretsantaorganizer.com 'export DBG=1; bash -s' < deploy.sh
+
+
 db-backup:
 	vagrant ssh -c "mysqldump -uroot -pvagrant secretsanta | gzip > /vagrant/dumps/database.sql.gz"
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,48 +1,82 @@
 #!/bin/bash
 
-set -x # xtrace: print commands
-set -e # errexit: exit on error
+function printAction {
+    if [ "$DBG" != 1 ]; then
+        let DOTS=40-${#1}
+        echo -n "$1 " >&2
+        printf '%0.s.' $(seq $DOTS) >&2
+        echo -n " " >&2
+    fi
+}
+
+function printOk {
+    if [ "$DBG" != 1 ]; then
+        echo -e "\033[32mOK\033[0m" >&2
+    fi
+}
+
+Q='-q'
+if [ "$DBG" = 1 ]; then
+    set -x # xtrace: print commands
+    Q=''
+else
+    exec > /dev/null
+fi
 
 PROJECT_HOME=/var/www/secretsanta
 VERSION=`date +"%Y%m%d%H%M%S"`
 export SYMFONY_ENV=prod
 cd $PROJECT_HOME
 
-# Get latest version
+printAction "Get latest version from Git"
 cd git
-git pull origin master
+git pull $Q origin master
 cd ..
+printOk
 
-# Deploy latest version
+printAction "Install latest version"
 cp -R git releases/$VERSION
 cd releases/$VERSION
 
 cp ../../shared/parameters.yml app/config
 cp ../../shared/client_secrets.json app/config
-composer.phar install --no-dev --classmap-authoritative
+printOk
 
-# Install assets
-bin/console assets:install web
+printAction "Composer install"
+composer.phar install --no-dev --classmap-authoritative $Q
+printOk
+
+printAction "Install assets"
+bin/console assets:install web $Q
 cp ../../shared/yandex_* web
+printOk
 
-# Cleanup
+printAction "Cleanup files and setting permissions"
 rm -rf .git .gitignore Vagrantfile shell_provisioner
 rm -rf web/app_{dev,test,test_travis}.php web/config.php
 
-# Reset permissions
 sudo chmod -R ug=rwX,o=rX ../$VERSION
 sudo chmod -R a+rwX var/logs var/cache
+printOk
 
-# Activate latest
+printAction "Stopping FPM"
 sudo service php7.2-fpm stop
-bin/console doctrine:schema:update --force --env=${SYMFONY_ENV}
+printOk
+printAction "Running doctrine schema update"
+bin/console doctrine:schema:update --force --env=${SYMFONY_ENV} $Q
 cd ../..
+printOk
+printAction "Activate new version"
 ln -sfn releases/$VERSION current
+printOk
+printAction "Starting FPM"
 sudo service php7.2-fpm start
+printOk
 
-# Cleanup old deployment, keep last 2
+printAction "Cleanup old versions, keep last 2"
 cd releases
 ls -1 | sort -r | tail -n +3 | xargs sudo rm -rf
 cd ..
+printOk
 
 echo SecretSanta version $VERSION is deployed!


### PR DESCRIPTION
Make the output of a ```make deploy``` pretty. If you want all the output for debugging, use ```make deploy-debug``` that has the output how it was. While this is a bit of overhead, I think it's acceptable.

![screenshot from 2018-02-09 21-05-01](https://user-images.githubusercontent.com/391674/36047909-cda01480-0ddd-11e8-97d9-d37b4f05427f.png)
