### PR TITLE
Allow participants to join by link (see #481)

### DIFF
--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -416,6 +416,21 @@ party_manage_valid:
                 Your participants will be notified of these changes immediately.
             </p>
 
+    join_mode:
+        title: Join by link settings
+        body: >
+            <p>
+                Instead of manually adding people, you can allow people to join your party by sharing a link.
+                <br />When you start the party, people aren't able to join anymore (but you can still add them manually).
+            </p>
+        mode:
+            no: No, do not allow people to join by link
+            yes: Yes, allow anyone with the link to join my party
+        reset_body: >
+            By checking this checkbox, a new link will be generated. People will not be able to join with the old link anymore.
+            Use this when the current link has been shared with people that are not supposed to be able to join.
+        reset_unset: Enable join by link to generate a link.
+
     btn:
         add_participant: Add participant to party
         add_participant_confirm: Add this participant
@@ -428,6 +443,8 @@ party_manage_valid:
         remove_participant_confirm: Remove this participant
         updated_party: Update your party details
         start_party: Start your party
+        join_mode: Join by link
+        join_mode_confirm: Set join mode
 
     label:
         name: Name
@@ -435,6 +452,9 @@ party_manage_valid:
         confirmed: Email status
         wishlist_filled: Wish List Entered
         actions: Actions
+        join_mode: Allow join by link
+        join_url: Share this URL with your friends
+        reset: Reset join URL
 
     excludes:
         title: Exclude certain combinations

--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -734,6 +734,9 @@ flashes:
         add_participant:
             success: <h4>Added!</h4> Participant successfully added to your party.
             danger: <h4>Oops</h4> An error occurred while adding the participant. Please try again.
+        join_mode:
+            success: <h4>Updated!</h4> The join by link settings have been successfully updated.
+            danger: <h4>Oops</h4> An error has occurred while updating the join by link settings. Please try again.
         updated_party:
             success: <h4>Updated!</h4> Your party details have been successfully updated.
             danger: <h4>Oops</h4> An error has occurred while updating your party. Please try again.

--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -467,6 +467,34 @@ party_manage_valid:
             name: Name
             exclude: Exclude
 
+party_join:
+    title: Join the party!
+    description: >
+        <p>
+            With the link you were given, you can add yourself to this Secret Santa party!
+            Please review the party details below, and fill out the form if you want to participate.
+            If you have questions regarding the party, please contact the person who created this party.
+        </p>
+    joined: >
+        <p>
+            We have added you to the party!
+            <br />Note that you will not receive your match until the party is started.
+            If you have any questions regarding the party or want to change your info, you must contact the person who created this party!
+        </p>
+    invalid: >
+        <p>
+            The link you have used is not valid. There could be several reasons for this
+            <ul>
+                <li>The party does not exists, or has been deleted.</li>
+                <li>The creator of the party has disabled or reset the link.</li>
+                <li>The party has already been started.</li>
+            </ul>
+            Please contact the person that sent you the link. He or she might still be able to add you to the party manually!
+        <p/>
+
+    btn:
+        join_confirm: Join party
+
 # Emails/baseEmail.html.twig
 emails-base_email:
     sender: Santa Claus

--- a/src/Intracto/SecretSantaBundle/Controller/Participant/JoinController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Participant/JoinController.php
@@ -8,12 +8,10 @@ use Intracto\SecretSantaBundle\Entity\Participant;
 use Intracto\SecretSantaBundle\Form\Type\AddParticipantType;
 use Intracto\SecretSantaBundle\Repository\PartyRepository;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Intracto\SecretSantaBundle\Entity\Party;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class JoinController extends AbstractController
 {
@@ -39,7 +37,7 @@ class JoinController extends AbstractController
                 $newParticipant->setParty($party);
                 $this->getDoctrine()->getManager()->persist($newParticipant);
                 $this->getDoctrine()->getManager()->flush();
-                return $this->redirectToRoute('join_party_joined', [ 'joinurl' => $party->getJoinurl() ]);
+                return $this->redirectToRoute('join_party_joined', ['joinurl' => $party->getJoinurl()]);
             }
         }
 

--- a/src/Intracto/SecretSantaBundle/Controller/Participant/JoinController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Participant/JoinController.php
@@ -21,7 +21,6 @@ class JoinController extends AbstractController
      */
     public function joinAction(Request $request, string $joinurl, PartyRepository $partyRepository)
     {
-
         /** @var Party $party */
         $party = $partyRepository->findOneBy(['joinurl' => $joinurl, 'joinmode' => 1, 'created' => 0]);
 
@@ -37,6 +36,7 @@ class JoinController extends AbstractController
                 $newParticipant->setParty($party);
                 $this->getDoctrine()->getManager()->persist($newParticipant);
                 $this->getDoctrine()->getManager()->flush();
+
                 return $this->redirectToRoute('join_party_joined', ['joinurl' => $party->getJoinurl()]);
             }
         }
@@ -45,7 +45,6 @@ class JoinController extends AbstractController
             'party' => $party,
             'form' => isset($addParticipantForm) ? $addParticipantForm->createView() : null,
         ];
-
     }
 
     /**

--- a/src/Intracto/SecretSantaBundle/Controller/Participant/JoinController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Participant/JoinController.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intracto\SecretSantaBundle\Controller\Participant;
+
+use Intracto\SecretSantaBundle\Entity\Participant;
+use Intracto\SecretSantaBundle\Form\Type\AddParticipantType;
+use Intracto\SecretSantaBundle\Repository\PartyRepository;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Intracto\SecretSantaBundle\Entity\Party;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class JoinController extends AbstractController
+{
+    /**
+     * @Route("/join/{joinurl}", name="join_party")
+     * @Template("IntractoSecretSantaBundle:Participant:show/join.html.twig")
+     */
+    public function joinAction(Request $request, string $joinurl, PartyRepository $partyRepository)
+    {
+
+        /** @var Party $party */
+        $party = $partyRepository->findOneBy(['joinurl' => $joinurl, 'joinmode' => 1, 'created' => 0]);
+
+        if (null !== $party) {
+            $addParticipantForm = $this->createForm(AddParticipantType::class, new Participant(), [
+                'action' => $this->generateUrl('join_party', ['joinurl' => $party->getJoinurl()]),
+            ]);
+            $addParticipantForm->handleRequest($request);
+
+            if ($addParticipantForm->isSubmitted() && $addParticipantForm->isValid()) {
+                /** @var Participant $newParticipant */
+                $newParticipant = $addParticipantForm->getData();
+                $newParticipant->setParty($party);
+                $this->getDoctrine()->getManager()->persist($newParticipant);
+                $this->getDoctrine()->getManager()->flush();
+                return $this->redirectToRoute('join_party_joined', [ 'joinurl' => $party->getJoinurl() ]);
+            }
+        }
+
+        return [
+            'party' => $party,
+            'form' => isset($addParticipantForm) ? $addParticipantForm->createView() : null,
+        ];
+
+    }
+
+    /**
+     * @Route("/joined/{joinurl}", name="join_party_joined")
+     * @Template("IntractoSecretSantaBundle:Participant:show/join.html.twig")
+     */
+    public function joinedAction(string $joinurl, PartyRepository $partyRepository)
+    {
+        /** @var Party $party */
+        $party = $partyRepository->findOneBy(['joinurl' => $joinurl, 'joinmode' => 1, 'created' => 0]);
+
+        return [
+            'party' => $party,
+            'form' => null,
+        ];
+    }
+
+}

--- a/src/Intracto/SecretSantaBundle/Controller/Participant/JoinController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Participant/JoinController.php
@@ -61,5 +61,4 @@ class JoinController extends AbstractController
             'form' => null,
         ];
     }
-
 }

--- a/src/Intracto/SecretSantaBundle/Controller/Party/ManagementController.php
+++ b/src/Intracto/SecretSantaBundle/Controller/Party/ManagementController.php
@@ -154,7 +154,6 @@ class ManagementController extends Controller
         $setJoinModeForm->handleRequest($request);
 
         if ($setJoinModeForm->isSubmitted() && $setJoinModeForm->isValid()) {
-
             if (($party->getJoinmode() == 1 && $party->getJoinurl() === null) || $request->request->get('reset', 0) == '1') {
                 // generate join URL
                 $party->setJoinurl(base_convert(sha1(uniqid((string) mt_rand(), true)), 16, 36));

--- a/src/Intracto/SecretSantaBundle/Entity/Party.php
+++ b/src/Intracto/SecretSantaBundle/Entity/Party.php
@@ -68,8 +68,8 @@ class Party
      */
     private $confirmed;
 
-    /** @var string */
-    private $joinurl = '';
+    /** @var ?string */
+    private $joinurl;
 
     /** @var int */
     private $joinmode = 0;
@@ -299,12 +299,12 @@ class Party
         $this->confirmed = (string) $confirmed;
     }
 
-    public function getJoinurl(): string
+    public function getJoinurl(): ?string
     {
         return $this->joinurl;
     }
 
-    public function setJoinurl(string $joinurl): void
+    public function setJoinurl(?string $joinurl): void
     {
         $this->joinurl = $joinurl;
     }

--- a/src/Intracto/SecretSantaBundle/Entity/Party.php
+++ b/src/Intracto/SecretSantaBundle/Entity/Party.php
@@ -68,6 +68,12 @@ class Party
      */
     private $confirmed;
 
+    /** @var string */
+    private $joinurl = '';
+
+    /** @var int */
+    private $joinmode = 0;
+
     public function __construct($createDefaults = true)
     {
         $this->participants = new ArrayCollection();
@@ -81,6 +87,7 @@ class Party
         $this->creationdate = new \DateTime();
         $this->message = '';
         $this->location = '';
+        $this->joinurl = base_convert(sha1(uniqid((string) mt_rand(), true)), 16, 36);
     }
 
     /**
@@ -290,6 +297,26 @@ class Party
     public function setConfirmed(bool $confirmed)
     {
         $this->confirmed = (string) $confirmed;
+    }
+
+    public function getJoinurl(): string
+    {
+        return $this->joinurl;
+    }
+
+    public function setJoinurl(string $joinurl): void
+    {
+        $this->joinurl = $joinurl;
+    }
+
+    public function getJoinmode(): int
+    {
+        return $this->joinmode;
+    }
+
+    public function setJoinmode(int $joinmode): void
+    {
+        $this->joinmode = $joinmode;
     }
 
     /**

--- a/src/Intracto/SecretSantaBundle/Form/Handler/JoinParticipantFormHandler.php
+++ b/src/Intracto/SecretSantaBundle/Form/Handler/JoinParticipantFormHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intracto\SecretSantaBundle\Form\Handler;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Intracto\SecretSantaBundle\Entity\Participant;
+use Intracto\SecretSantaBundle\Entity\Party;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class JoinParticipantFormHandler
+{
+    private TranslatorInterface $translator;
+    private Session $session;
+    private EntityManager $em;
+
+    public function __construct(TranslatorInterface $translator, SessionInterface $session, EntityManagerInterface $em)
+    {
+        $this->translator = $translator;
+        $this->session = $session;
+        $this->em = $em;
+    }
+
+    public function handle(FormInterface $form, Request $request, Party $party): void
+    {
+        /** @var Participant $newParticipant */
+        $newParticipant = $form->getData();
+
+        if (!$request->isMethod('POST')) {
+            return;
+        }
+
+        if (!$form->handleRequest($request)->isValid()) {
+            $this->session->getFlashBag()->add('danger', $this->translator->trans('flashes.management.add_participant.danger'));
+
+            return;
+        }
+
+        $newParticipant->setParty($party);
+
+        $this->em->persist($newParticipant);
+        $this->em->flush();
+
+        $this->session->getFlashBag()->add('success', $this->translator->trans('flashes.management.add_participant.success'));
+    }
+}

--- a/src/Intracto/SecretSantaBundle/Form/Type/SetJoinModeType.php
+++ b/src/Intracto/SecretSantaBundle/Form/Type/SetJoinModeType.php
@@ -18,7 +18,7 @@ class SetJoinModeType extends AbstractType
                 ChoiceType::class,
                 [
                     'attr' => ['data-hj-masked' => ''],
-                    'choices' => [ 'party_manage_valid.join_mode.mode.no' => '0', 'party_manage_valid.join_mode.mode.yes' => '1'],
+                    'choices' => ['party_manage_valid.join_mode.mode.no' => '0', 'party_manage_valid.join_mode.mode.yes' => '1'],
                     'expanded' => true,
                     'multiple' => false,
                 ]

--- a/src/Intracto/SecretSantaBundle/Form/Type/SetJoinModeType.php
+++ b/src/Intracto/SecretSantaBundle/Form/Type/SetJoinModeType.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Intracto\SecretSantaBundle\Form\Type;
+
+use Intracto\SecretSantaBundle\Entity\Party;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class SetJoinModeType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'join_mode',
+                ChoiceType::class,
+                [
+                    'attr' => ['data-hj-masked' => ''],
+                    'choices' => [ 'party_manage_valid.join_mode.mode.no' => '0', 'party_manage_valid.join_mode.mode.yes' => '1'],
+                    'expanded' => true,
+                    'multiple' => false,
+                ]
+            )
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => Party::class,
+        ]);
+    }
+}

--- a/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Party.orm.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Party.orm.xml
@@ -10,6 +10,7 @@
         <indexes>
             <index name="list_url" columns="list_url"/>
             <index name="dates" columns="created,event_date,sent_date"/>
+            <index name="join_url" columns="join_url"/>
         </indexes>
 
         <id name="id" type="integer">
@@ -34,6 +35,9 @@
         <field name="created" column="created" type="boolean"/>
         <field name="locale" column="locale" type="string" length="7"/>
         <field name="location" column="location" type="string" length="255" nullable="true"/>
+
+        <field name="joinurl" column="join_url" type="string" length="50" unique="true"/>
+        <field name="joinmode" column="join_mode" type="integer"/>
     </entity>
 
 </doctrine-mapping>

--- a/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Party.orm.xml
+++ b/src/Intracto/SecretSantaBundle/Resources/config/doctrine/Party.orm.xml
@@ -10,7 +10,6 @@
         <indexes>
             <index name="list_url" columns="list_url"/>
             <index name="dates" columns="created,event_date,sent_date"/>
-            <index name="join_url" columns="join_url"/>
         </indexes>
 
         <id name="id" type="integer">
@@ -36,7 +35,7 @@
         <field name="locale" column="locale" type="string" length="7"/>
         <field name="location" column="location" type="string" length="255" nullable="true"/>
 
-        <field name="joinurl" column="join_url" type="string" length="50" unique="true"/>
+        <field name="joinurl" column="join_url" type="string" length="50" nullable="true" unique="true"/>
         <field name="joinmode" column="join_mode" type="integer"/>
     </entity>
 

--- a/src/Intracto/SecretSantaBundle/Resources/public/js/party.manage.js
+++ b/src/Intracto/SecretSantaBundle/Resources/public/js/party.manage.js
@@ -44,6 +44,11 @@ $(document).ready(function () {
         $('.link_remove_participant').attr('disabled', false);
     });
 
+    $('#btn_join').click(function (e) {
+        $('#join-mode').show();
+        $('#btn_join').attr('disabled', true);
+    });
+
     if (Modernizr.inputtypes.date == true) {
         $("#intracto_secretsantabundle_updatepartydetailstype_eventdate").click(function (e) {
             $(this).datepicker({dateFormat: 'dd-mm-yy'});

--- a/src/Intracto/SecretSantaBundle/Resources/views/Participant/show/join.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Participant/show/join.html.twig
@@ -1,0 +1,66 @@
+{% extends "IntractoSecretSantaBundle:Participant/show:base.html.twig" %}
+
+{% block main %}
+    <div class="box">
+        <div class="row participant-title-row">
+            <div class="col-xs-12 col-sm-12 col-md-12">
+                <h1>{{ 'party_join.title'|trans }}</h1>
+
+                {% if party is not null %}
+
+                    {{ 'party_join.description'|trans|raw }}
+
+                    {% if form is null %}
+                        <div class="alert alert-success">
+                            {{ 'party_join.joined'|trans|raw }}
+                        </div>
+                    {% endif %}
+
+                    <div class="party-info">
+                        <h2>{{ 'participant_show_base.headers.title'|trans|raw }}</h2>
+                        <div id="partyDetails">
+                            <ul class="liststyle1">
+                                <li><strong>{{ 'participant_show_base.headers.date'|trans }}: </strong> {{ party.eventdate|localizeddate('medium', 'none') }}</li>
+                                <li><strong>{{ 'participant_show_base.headers.location'|trans }}: </strong> {{ party.location }}</li>
+                                <li><strong>{{ 'participant_show_base.headers.amount'|trans }}: </strong> {{ party.amount }}</li>
+                                <li><strong>{{ 'participant_show_base.headers.person_created_list'|trans }}: </strong> <span data-hj-masked>{{ party.participants|first.name }} ({{ party.participants|first.email }})</span>
+                            </ul>
+                        </div>
+                    </div>
+
+                    {% if form is not null %}
+                        {{ form_start(form) }}
+                        {{ form_row(form._token) }}
+                        <div class="form-group {% if form_errors(form.name) %}error{% endif %}">
+                            <strong>{{ 'party_manage_valid.label.name'|trans }}</strong> {{ form_widget(form.name ,{'attr':{'class':'form-control'}}) }}
+                            {% if form_errors(form.name) %}
+                                {% for error in form.name.vars.errors %}
+                                    <strong>{{ error.message }}</strong><br/>
+                                {% endfor %}
+                            {% endif %}
+                        </div>
+                        <div class="form-group {% if form_errors(form.email) %}error{% endif %}">
+                            <strong>{{ 'party_manage_valid.label.email'|trans }}</strong> {{ form_widget(form.email ,{'attr':{'class':'form-control'}}) }}
+                            {% if form_errors(form.email) %}
+                                {% for error in form.email.vars.errors %}
+                                    <strong>{{ error.message }}</strong><br/>
+                                {% endfor %}
+                            {% endif %}
+                        </div>
+                        <button type="submit" class="btn btn-success"
+                                id="btn_add_confirmation">{{ 'party_join.btn.join_confirm'|trans|raw }}</button>
+                        <button type="reset" class="btn btn-success" id="btn_add_cancel">{{ 'party_manage_valid.btn.cancel'|trans }}</button>
+                        {{ form_end(form) }}
+                    {% endif %}
+                {% else %}
+                    <div class="alert alert-danger">
+                        {{ 'party_join.invalid'|trans|raw }}
+                    </div>
+                {% endif %}
+
+            </div>
+        </div>
+
+    </div>
+
+{% endblock %}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
@@ -109,6 +109,9 @@
                 {% if (form_errors(addParticipantForm.name)) or (form_errors(addParticipantForm.email)) %}disabled{% endif %}>
             <i class="fa fa-plus-circle fa-inverse"></i> {{ 'party_manage_valid.btn.add_participant'|trans|raw }}
         </button>
+        <button id="btn_join" class="btn btn-info manage_btn" style="float: right; margin-bottom: 35px;" {% if party.created %}disabled{% endif %}>
+            <i class="fa fa-link fa-inverse"></i> {{ 'party_manage_valid.btn.join_mode'|trans|raw }}
+        </button>
         <div class="clearfix"></div>
         <div id="add-participant" class="alert alert-success manage-page-form"
              {% if (form_errors(addParticipantForm.name)) or (form_errors(addParticipantForm.email)) %}style="display: block;"
@@ -159,6 +162,36 @@
                     {{ 'party_manage_valid.btn.cancel'|trans }}
                 </button>
             </form>
+        </div>
+        <div class="clearfix"></div>
+        <div id="join-mode" class="alert alert-success manage-page-form" style="display: none">
+            <h3>{{ 'party_manage_valid.join_mode.title'|trans|raw }}</h3>
+
+            {{ 'party_manage_valid.join_mode.body'|trans|raw }}
+
+            <br>
+            {{ form_start(setJoinModeForm) }}
+            {{ form_row(setJoinModeForm._token) }}
+
+            <div class="form-group">
+                <strong>{{ 'party_manage_valid.label.join_mode'|trans }}</strong> {{ form_widget(setJoinModeForm.join_mode ,{'attr':{'class':'form-control'}}) }}
+                {% if form_errors(setJoinModeForm.join_mode) %}setJoinModeForm
+                    {% for error in setJoinModeForm.name.vars.errors %}
+                        <strong>{{ error.message }}</strong><br/>
+                    {% endfor %}
+                {% endif %}
+            </div>
+            <div class="form-group">
+                <strong>{{ 'party_manage_valid.label.join_url'|trans }}</strong> <input type="text" disabled="disabled" value="{% if party.joinurl is null %}{{'party_manage_valid.join_mode.reset_unset'|trans }}{% else %}{{ party.joinurl }}{% endif %}" class="form-control">
+            </div>
+            <div class="form-group">
+                <strong>{{ 'party_manage_valid.label.reset'|trans }}</strong> <input type="checkbox" name="reset" value="1" class="form-check-inline"/>
+                <p>{{ 'party_manage_valid.join_mode.reset_body'|trans }}</p>
+            </div>
+            <button type="submit" class="btn btn-success"
+                    id="btn_joinmode_confirmation">{{ 'party_manage_valid.btn.join_mode_confirm'|trans|raw }}</button>
+            <button type="reset" class="btn btn-success" id="btn_joinmode_cancel">{{ 'party_manage_valid.btn.cancel'|trans }}</button>
+            {{ form_end(setJoinModeForm) }}
         </div>
 
         {% if party.created %}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
@@ -182,7 +182,7 @@
                 {% endif %}
             </div>
             <div class="form-group">
-                <strong>{{ 'party_manage_valid.label.join_url'|trans }}</strong> <input type="text" disabled="disabled" value="{% if party.joinurl is null %}{{'party_manage_valid.join_mode.reset_unset'|trans }}{% else %}{{ party.joinurl }}{% endif %}" class="form-control">
+                <strong>{{ 'party_manage_valid.label.join_url'|trans }}</strong> <input type="text" disabled="disabled" value="{% if party.joinurl is null %}{{'party_manage_valid.join_mode.reset_unset'|trans }}{% else %}{{ absolute_url(path('join_party', {joinurl: party.joinurl})) }}{% endif %}" class="form-control">
             </div>
             <div class="form-group">
                 <strong>{{ 'party_manage_valid.label.reset'|trans }}</strong> <input type="checkbox" name="reset" value="1" class="form-check-inline"/>

--- a/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
@@ -125,7 +125,7 @@
             {{ form_row(addParticipantForm._token) }}
             <div class="form-group {% if form_errors(addParticipantForm.name) %}error{% endif %}">
                 <strong>{{ 'party_manage_valid.label.name'|trans }}</strong> {{ form_widget(addParticipantForm.name ,{'attr':{'class':'form-control'}}) }}
-                {% if form_errors(addParticipantForm.name) %}addParticipantForm
+                {% if form_errors(addParticipantForm.name) %}
                     {% for error in addParticipantForm.name.vars.errors %}
                         <strong>{{ error.message }}</strong><br/>
                     {% endfor %}

--- a/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
+++ b/src/Intracto/SecretSantaBundle/Resources/views/Party/manage/valid.html.twig
@@ -164,7 +164,7 @@
             </form>
         </div>
         <div class="clearfix"></div>
-        <div id="join-mode" class="alert alert-success manage-page-form" style="display: none">
+        <div id="join-mode" class="alert alert-info manage-page-form" style="display: none">
             <h3>{{ 'party_manage_valid.join_mode.title'|trans|raw }}</h3>
 
             {{ 'party_manage_valid.join_mode.body'|trans|raw }}
@@ -188,9 +188,9 @@
                 <strong>{{ 'party_manage_valid.label.reset'|trans }}</strong> <input type="checkbox" name="reset" value="1" class="form-check-inline"/>
                 <p>{{ 'party_manage_valid.join_mode.reset_body'|trans }}</p>
             </div>
-            <button type="submit" class="btn btn-success"
+            <button type="submit" class="btn btn-info"
                     id="btn_joinmode_confirmation">{{ 'party_manage_valid.btn.join_mode_confirm'|trans|raw }}</button>
-            <button type="reset" class="btn btn-success" id="btn_joinmode_cancel">{{ 'party_manage_valid.btn.cancel'|trans }}</button>
+            <button type="reset" class="btn btn-info" id="btn_joinmode_cancel">{{ 'party_manage_valid.btn.cancel'|trans }}</button>
             {{ form_end(setJoinModeForm) }}
         </div>
 


### PR DESCRIPTION
Implemented #481 

Added functionality to manage page to enable or disable "join by link". When enabled, anyone with the correct link can subscribe to the party, as long as the party has not been started yet or the manager hasn't disabled it again. The link can also be reset in case it is compromised.  

At this point, there's no functionality added to actually share the link or invite people from within the platform. It is up to the manager of the party to distribute the link.  

Branch is based on the current master branch. Given the relatively simple implementation, it should not be a lot of work porting this to the SF4 branch once we move forward with that.