### PR TITLE
Fix the tooltip translation for host

### DIFF
--- a/translations/messages.zh-Hant.yml
+++ b/translations/messages.zh-Hant.yml
@@ -63,7 +63,7 @@ party-create:
 #    rate_limit_reached: ?
 
     add_participants: 加入你的參加者
-    list_adminstrator: 這人是你的名單管理者。
+    list_adminstrator: 這人也是參加者。
     add_personal_message:
         title: 加入個人信息
         description: 為參加者加入個人信息。


### PR DESCRIPTION
 The original translation `這人是你的名單管理者。` does not match the original sentence. `This person is a participant too.`
It should be 參加者 instead of 名單管理者.
